### PR TITLE
Add utility mvn wrapper scripts for fast local install, unit tests, ...

### DIFF
--- a/dev-ops/util/README.md
+++ b/dev-ops/util/README.md
@@ -1,0 +1,26 @@
+Collection of utility scripts wrapping common task (mvn local install, test,...)
+
+Example ussage:
+
+     $ cd /home/interledger/workspace01/quilt/
+     $ ./dev-ops/util/quick_local_install_mvn_package.sh
+     Output must be similar to:
+     ...
+    [INFO] BUILD SUCCESS
+    [INFO] ------------------------------------------------------------------------
+    [INFO] Total time: 5.098 s
+    ..
+    $ cd ilp-core
+    $ ../dev-ops/util/unit_tests.sh
+    Output must be similar to:
+    ...
+    [INFO] BUILD SUCCESS
+    ...
+    +--------------------------------------
+    | Coverage reports available at:
+    | /home/interledger/workspace01/quilt/ilp-core/target/site/jacoco/index.html
+    +--------------------------------------
+
+
+Environment Variables: 
+`MVN_OPTS`: pass extra options to maven. 

--- a/dev-ops/util/full_local_install_mvn_package.sh
+++ b/dev-ops/util/full_local_install_mvn_package.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Description:
+# install to local maven repository 
+#  executing first all tests , check-styles, exec javaDoc,...
+
+set -eu
+
+if [ ! -f pom.xml ] ; then echo "Not pom.xml file found in current directory" ; exit 0 ; fi
+
+if [ -z ${MVN_OPTS+x} ]; then MVN_OPTS=""; fi
+
+mvn $MVN_OPTS clean install

--- a/dev-ops/util/quick_local_install_mvn_package.sh
+++ b/dev-ops/util/quick_local_install_mvn_package.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Description:
+#   fast install to local maven repository bypassing  
+#   check-style , unit-tests and javaDoc
+
+set -eu
+
+if [ ! -f pom.xml ] ; then echo "Not pom.xml file found in current directory" ; exit 0 ; fi
+
+if [ -z ${MVN_OPTS+x} ]; then MVN_OPTS=""; fi
+
+# REF: Listing map phase (1 <-> N) goals:
+#  https://stackoverflow.com/questions/1709625/maven-command-to-list-lifecycle-phases-along-with-bound-goals
+#  mvn fr.jcgay.maven.plugins:buildplan-maven-plugin:list -Dbuildplan.tasks=install
+
+mvn $MVN_OPTS resources:resources compiler:compile jar:jar install:install

--- a/dev-ops/util/show_mvn_dependency_tree.sh
+++ b/dev-ops/util/show_mvn_dependency_tree.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Description:
+#   Show maven dependency graph for pom.xml in CWD
+
+set -eu
+
+if [ ! -f pom.xml ] ; then echo "Not pom.xml file found in current directory" ; exit 0 ; fi
+
+if [ -z ${MVN_OPTS+x} ]; then MVN_OPTS=""; fi
+
+# REF: Listing map phase (1 <-> N) goals:
+#  https://stackoverflow.com/questions/1709625/maven-command-to-list-lifecycle-phases-along-with-bound-goals
+#  mvn fr.jcgay.maven.plugins:buildplan-maven-plugin:list -Dbuildplan.tasks=install
+
+
+mvn $MVN_OPTS dependency:tree

--- a/dev-ops/util/unit_tests.sh
+++ b/dev-ops/util/unit_tests.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Description:
+#   Exec Unit-Test mvn phase only
+
+set -eu
+
+if [ ! -f pom.xml ] ; then echo "Not pom.xml file found in current directory" ; exit 0 ; fi
+
+if [ -z ${MVN_OPTS+x} ]; then MVN_OPTS=""; fi
+
+mvn $MVN_OPTS test
+
+CWD=`pwd`
+cat << EOF
+
+
+
+ +--------------------------------------
+ | Coverage reports available at:
+ | $CWD/target/site/jacoco/index.html
+ +--------------------------------------
+
+
+EOF


### PR DESCRIPTION
wrappers scripts around common maven tasks. 

Hopefully the same or similar scripts can be reused by CI/dev-ops tasks. 

See example usage in `dev-ops/utils/README.md`