### PR TITLE
Fixes #71

### DIFF
--- a/crypto-conditions/src/main/java/org/interledger/cryptoconditions/ThresholdSha256Condition.java
+++ b/crypto-conditions/src/main/java/org/interledger/cryptoconditions/ThresholdSha256Condition.java
@@ -148,6 +148,13 @@ public final class ThresholdSha256Condition extends CompoundSha256Condition
   ) {
     Objects.requireNonNull(subconditions);
 
+    // Ensure a sufficient number of sub-conditions
+    if (subconditions.size() < threshold) {
+      throw new IllegalArgumentException(
+          "The number of valid sub-fulfillments must be equal or greater than the threshold"
+      );
+    }
+
     // Sort by cost
     subconditions.sort((Condition c1, Condition c2) -> (int) (c2.getCost() - c1.getCost()));
 


### PR DESCRIPTION
* Ensure no sub-conditions underflow (towards threshold) in the THRESHOLD-SHA-256 condition class

Signed-off-by: Pascal Avondes <pavondes@gmail.com>