### PR TITLE
Add connector folders

### DIFF
--- a/connector-examples/README.md
+++ b/connector-examples/README.md
@@ -1,0 +1,8 @@
+# Interledger Connector Examples
+This project contains examples of Interledger Connectors that are built using various f
+rameworks, such as [Spring](https://spring.io/), [Vertx](http://vertx.io/), and others. 
+
+The intention of the connector projects in this folder is to both provide reference 
+implementations of an Interledger Connector, while at the same time illustrate the flexibility 
+of the ILP Core components by showing how they can be wired into a diversity of existing Java 
+frameworks and technologies.

--- a/connector-examples/pom.xml
+++ b/connector-examples/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <parent>
+    <groupId>org.interledger</groupId>
+    <artifactId>quilt-parent</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.interledger</groupId>
+  <artifactId>connector-examples</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <name>Interledger Connector Examples</name>
+  <description>
+    Example ILP connector implementations using various frameworks and underlying technologies.
+  </description>
+  <inceptionYear>2018</inceptionYear>
+  <packaging>pom</packaging>
+
+  <modules></modules>
+
+  <!-- List all Connector Dependency Management here, and not in quilt-parent -->
+  <dependencyManagement>
+  </dependencyManagement>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
     <module>crypto-conditions</module>
     <module>ilp-core</module>
     <module>ilp-annotations</module>
+    <module>connector-examples</module>
   </modules>
 
   <dependencyManagement>


### PR DESCRIPTION
During the quilt call, we all agreed it would be ideal to locate various connector implementations _in_ the Quilt project. This commit provides some scaffolding to organize that effort.