### PR TITLE
Fixes #119

### DIFF
--- a/ilp-core-codecs/README.md
+++ b/ilp-core-codecs/README.md
@@ -24,7 +24,6 @@ final InterledgerPreparePacket packet
   .executionCondition(
       PreimageSha256Condition.fromCostAndFingerprint(32, preimage))
   .expiresAt(Instant.now().plus().plusSeconds(30))
-  .data(new byte[] {})
   .build();
 
 context.write(packet, outputStream);

--- a/ilp-core-codecs/src/test/java/org/interledger/core/asn/codecs/InterledgerPreparePacketOerSerializerTests.java
+++ b/ilp-core-codecs/src/test/java/org/interledger/core/asn/codecs/InterledgerPreparePacketOerSerializerTests.java
@@ -55,8 +55,7 @@ public class InterledgerPreparePacketOerSerializerTests {
             .destination(InterledgerAddress.of("test3.foo.bar"))
             .amount(BigInteger.valueOf(100L))
             .executionCondition(PreimageSha256Condition.fromCostAndFingerprint(32, condition))
-            .expiresAt(Instant.now())
-            .data(new byte[] {}).build()},
+            .expiresAt(Instant.now()).build()},
 
         {InterledgerPreparePacket.builder()
             .destination(InterledgerAddress.builder().value("test1.bar.baz").build())

--- a/ilp-core/src/main/java/org/interledger/core/InterledgerFulfillPacket.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerFulfillPacket.java
@@ -3,6 +3,8 @@ package org.interledger.core;
 import org.interledger.annotations.Immutable;
 import org.interledger.cryptoconditions.PreimageSha256Fulfillment;
 
+import org.immutables.value.Value.Default;
+
 import java.util.Arrays;
 
 public interface InterledgerFulfillPacket extends InterledgerPacket {
@@ -29,6 +31,11 @@ public interface InterledgerFulfillPacket extends InterledgerPacket {
   @Immutable
   abstract class AbstractInterledgerFulfillPacket implements InterledgerFulfillPacket {
 
+    @Override
+    @Default
+    public byte[] getData() {
+      return new byte[0];
+    }
   }
 
 }

--- a/ilp-core/src/main/java/org/interledger/core/InterledgerPreparePacket.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerPreparePacket.java
@@ -3,6 +3,8 @@ package org.interledger.core;
 import org.interledger.annotations.Immutable;
 import org.interledger.cryptoconditions.PreimageSha256Condition;
 
+import org.immutables.value.Value.Default;
+
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.Arrays;
@@ -76,6 +78,11 @@ public interface InterledgerPreparePacket extends InterledgerPacket {
   @Immutable
   abstract class AbstractInterledgerPreparePacket implements InterledgerPreparePacket {
 
+    @Override
+    @Default
+    public byte[] getData() {
+      return new byte[0];
+    }
   }
 
 }

--- a/ilp-core/src/main/java/org/interledger/core/InterledgerRejectPacket.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerRejectPacket.java
@@ -2,6 +2,8 @@ package org.interledger.core;
 
 import org.interledger.annotations.Immutable;
 
+import org.immutables.value.Value.Default;
+
 import java.util.Arrays;
 
 public interface InterledgerRejectPacket extends InterledgerPacket {
@@ -47,5 +49,10 @@ public interface InterledgerRejectPacket extends InterledgerPacket {
   @Immutable
   abstract class AbstractInterledgerRejectPacket implements InterledgerRejectPacket {
 
+    @Override
+    @Default
+    public byte[] getData() {
+      return new byte[0];
+    }
   }
 }

--- a/ilp-core/src/test/java/org/interledger/core/InterledgerPreparePacketTest.java
+++ b/ilp-core/src/test/java/org/interledger/core/InterledgerPreparePacketTest.java
@@ -64,10 +64,8 @@ public class InterledgerPreparePacketTest {
           .executionCondition(mock(PreimageSha256Condition.class))
           .expiresAt(Instant.now())
           .build();
-      fail();
     } catch (IllegalStateException e) {
-      assert (e.getMessage().startsWith("Cannot build InterledgerPreparePacket, "
-          + "some of required attributes are not set"));
+      fail();
     }
 
     //No expiry
@@ -76,7 +74,6 @@ public class InterledgerPreparePacketTest {
           .destination(mock(InterledgerAddress.class))
           .amount(mock(BigInteger.class))
           .executionCondition(mock(PreimageSha256Condition.class))
-          .data(new byte[]{})
           .build();
       fail();
     } catch (IllegalStateException e) {
@@ -90,7 +87,6 @@ public class InterledgerPreparePacketTest {
           .destination(mock(InterledgerAddress.class))
           .amount(mock(BigInteger.class))
           .expiresAt(Instant.now())
-          .data(new byte[]{})
           .build();
       fail();
     } catch (IllegalStateException e) {
@@ -104,7 +100,6 @@ public class InterledgerPreparePacketTest {
           .destination(mock(InterledgerAddress.class))
           .executionCondition(mock(PreimageSha256Condition.class))
           .expiresAt(Instant.now())
-          .data(new byte[]{})
           .build();
       fail();
     } catch (IllegalStateException e) {
@@ -119,7 +114,6 @@ public class InterledgerPreparePacketTest {
           .amount(mock(BigInteger.class))
           .executionCondition(mock(PreimageSha256Condition.class))
           .expiresAt(Instant.now())
-          .data(new byte[]{})
           .build();
       fail();
     } catch (IllegalStateException e) {
@@ -133,7 +127,6 @@ public class InterledgerPreparePacketTest {
             .amount(mock(BigInteger.class))
             .executionCondition(mock(PreimageSha256Condition.class))
             .expiresAt(Instant.now())
-            .data(new byte[]{})
             .build();
     assertThat(interledgerPreparePacket, is(not(nullValue())));
   }

--- a/ilp-core/src/test/java/org/interledger/core/InterledgerRejectPacketTest.java
+++ b/ilp-core/src/test/java/org/interledger/core/InterledgerRejectPacketTest.java
@@ -121,7 +121,6 @@ public class InterledgerRejectPacketTest {
         .code(InterledgerErrorCode.T00_INTERNAL_ERROR)
         .message(message)
         .triggeredBy(FOO)
-        .data(new byte[]{})
         .build();
 
     final InterledgerRejectPacket interledgerProtocolError2
@@ -129,7 +128,6 @@ public class InterledgerRejectPacketTest {
         .code(InterledgerErrorCode.T00_INTERNAL_ERROR)
         .message(message)
         .triggeredBy(FOO)
-        .data(new byte[]{})
         .build();
 
     assertThat(interledgerProtocolError1, is(interledgerProtocolError2));
@@ -144,7 +142,6 @@ public class InterledgerRejectPacketTest {
         .code(InterledgerErrorCode.T99_APPLICATION_ERROR)
         .message(message)
         .triggeredBy(FOO)
-        .data(new byte[]{})
         .build();
 
     assertFalse(interledgerProtocolError1.equals(interledgerProtocolErrorOther));


### PR DESCRIPTION
* Eases the ILP v4 packets impl usage by initializing their 'data' field to empty.

Signed-off-by: Pascal Avondes <pavondes@gmail.com>