### PR TITLE
Feature/npe enforcements

### DIFF
--- a/ilp-core/src/main/java/org/interledger/core/InterledgerAddress.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerAddress.java
@@ -37,8 +37,11 @@ public interface InterledgerAddress {
    * @param value String representation of an Interledger Address
    *
    * @return an {@link InterledgerAddress} instance.
+   *
+   * @throws NullPointerException if {@code value} is <tt>null</tt>.
    */
   static InterledgerAddress of(final String value) {
+    Objects.requireNonNull(value, "value must not be null!");
     return new InterledgerAddressBuilder().value(value).build();
   }
 
@@ -50,16 +53,18 @@ public interface InterledgerAddress {
    *
    * @return {@code true} if the supplied {@code value} conforms to the requirements of RFC 15;
    *     {@code false} otherwise.
+   *
+   * @throws NullPointerException if {@code value} is <tt>null</tt>.
    */
   static boolean isValid(final String value) {
-    Objects.requireNonNull(value);
+    Objects.requireNonNull(value, "value must not be null!");
     ADDRESS_PARSER.validate(value);
     return true;
   }
 
   /**
    * <p>Checks and requires that the specified {@code address} is an address prefix per {@link
-   * InterledgerAddressParser#requireAddressPrefix(InterledgerAddress)}.</p>
+   * InterledgerAddress#isLedgerPrefix()}.</p>
    *
    * <p>This method is designed primarily for doing parameter validation in methods and
    * constructors, as demonstrated below:</p>
@@ -76,16 +81,28 @@ public interface InterledgerAddress {
    *
    * @return The supplied {@code address} if its value ends with a dot (.).
    *
-   * @throws IllegalArgumentException if the supplied address is not a <tt>ledger-prefix</tt>.
+   * @throws NullPointerException     if the supplied {@code address} is <tt>null</tt>.
+   * @throws IllegalArgumentException if the supplied {@code address} is <tt>not</tt> a
+   *                                  <tt>ledger-prefix</tt>.
    */
   static InterledgerAddress requireAddressPrefix(final InterledgerAddress address) {
-    return ADDRESS_PARSER.requireAddressPrefix(address);
+    Objects.requireNonNull(address, "address must not be null!");
+
+    if (!address.isLedgerPrefix()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "InterledgerAddress '%s' must be an Address Prefix ending with a dot (.)",
+              address.getValue()
+          )
+      );
+    } else {
+      return address;
+    }
   }
 
   /**
    * <p>Checks and requires that the specified {@code address} is an address prefix per {@link
-   * InterledgerAddressParser#requireAddressPrefix(InterledgerAddress, String)}, providing an error
-   * message upon invalidation.</p>
+   * InterledgerAddress#isLedgerPrefix()}, providing an error message upon invalidation.</p>
    *
    * <p>This method is designed primarily for doing parameter validation in methods and
    * constructors, as demonstrated below:</p>
@@ -104,17 +121,26 @@ public interface InterledgerAddress {
    *
    * @return The supplied {@code address} if its value ends with a dot <tt>(.)</tt>.
    *
-   * @throws IllegalArgumentException if the supplied address is not a ledger-prefix.
+   * @throws NullPointerException     if the supplied {@code address} or {@code errorMessage} is
+   *                                  <tt>null</tt>.
+   * @throws IllegalArgumentException if the supplied {@code address} is not a ledger-prefix.
    */
   static InterledgerAddress requireAddressPrefix(
       final InterledgerAddress address, final String errorMessage
   ) {
-    return ADDRESS_PARSER.requireAddressPrefix(address, errorMessage);
+    Objects.requireNonNull(address, "address must not be null!");
+    Objects.requireNonNull(errorMessage, "errorMessage must not be null!");
+
+    if (!address.isLedgerPrefix()) {
+      throw new IllegalArgumentException(errorMessage);
+    }
+
+    return address;
   }
 
   /**
    * <p>Checks and requires that the specified {@code address} is not an address prefix per {@link
-   * InterledgerAddressParser#requireNotAddressPrefix(InterledgerAddress)}.</p>
+   * InterledgerAddress#isLedgerPrefix()}.</p>
    *
    * <p>This method is designed primarily for doing parameter validation in methods and
    * constructors, as demonstrated below:</p>
@@ -131,16 +157,26 @@ public interface InterledgerAddress {
    *
    * @return The supplied {@code address} if its value ends with a dot <tt>(.)</tt>.
    *
-   * @throws IllegalArgumentException if the supplied address is a ledger-prefix.
+   * @throws NullPointerException     if the supplied {@code address} is <tt>null</tt>.
+   * @throws IllegalArgumentException if the supplied {@code address} is a ledger-prefix.
    */
   static InterledgerAddress requireNotAddressPrefix(final InterledgerAddress address) {
-    return ADDRESS_PARSER.requireNotAddressPrefix(address);
+    Objects.requireNonNull(address, "address must not be null!");
+
+    if (address.isLedgerPrefix()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "InterledgerAddress '%s' must NOT be an Address Prefix ending with a dot (.)",
+              address.getValue())
+      );
+    }
+
+    return address;
   }
 
   /**
    * <p>Checks and requires that the specified {@code address} is not an address prefix per {@link
-   * InterledgerAddressParser#requireNotAddressPrefix(InterledgerAddress, String)}, providing an
-   * error message upon invalidation.</p>
+   * InterledgerAddress#isLedgerPrefix()}, providing an error message upon invalidation.</p>
    *
    * <p>This method is designed primarily for doing parameter validation in methods and
    * constructors, as demonstrated below:</p>
@@ -160,12 +196,21 @@ public interface InterledgerAddress {
    *
    * @return The supplied {@code address} if its value ends with a dot (.).
    *
-   * @throws IllegalArgumentException if the supplied address is a ledger-prefix.
+   * @throws NullPointerException     if the supplied {@code address} or {@code errorMessage} is
+   *                                  <tt>null</tt>.
+   * @throws IllegalArgumentException if the supplied {@code address} is a ledger-prefix.
    */
   static InterledgerAddress requireNotAddressPrefix(
       final InterledgerAddress address, final String errorMessage
   ) {
-    return ADDRESS_PARSER.requireNotAddressPrefix(address, errorMessage);
+    Objects.requireNonNull(address, "address must not be null!");
+    Objects.requireNonNull(errorMessage, "errorMessage must not be null!");
+
+    if (address.isLedgerPrefix()) {
+      throw new IllegalArgumentException(errorMessage);
+    }
+
+    return address;
   }
 
   /**
@@ -211,7 +256,8 @@ public interface InterledgerAddress {
    *
    * @param interledgerAddress An {@link InterledgerAddress} prefix to compare against.
    *
-   * @return {@code true} if this InterledgerAddress begins with the specified prefix.
+   * @return {@code true} if the supplied {@code interledgerAddress} begins with the specified
+   *     prefix.
    */
   default boolean startsWith(final InterledgerAddress interledgerAddress) {
     Objects.requireNonNull(interledgerAddress, "interledgerAddress must not be null!");
@@ -237,7 +283,7 @@ public interface InterledgerAddress {
    *
    * @return A new instance representing the original address with a newly specified final segment.
    */
-  default InterledgerAddress with(String addressSegment) {
+  default InterledgerAddress with(final String addressSegment) {
     Objects.requireNonNull(addressSegment, "addressSegment must not be null!");
 
     final StringBuilder sb = new StringBuilder(this.getValue());

--- a/ilp-core/src/main/java/org/interledger/core/InterledgerAddress.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerAddress.java
@@ -363,7 +363,7 @@ public interface InterledgerAddress {
    *     return {@code true}.
    */
   default boolean hasParentPrefix() {
-    // All ILP addresse have a parent prefix, except for Root prefixes.
+    // All ILP addresses have a parent prefix, except for Root prefixes.
     return isRootPrefix() == false;
   }
 

--- a/ilp-core/src/main/java/org/interledger/core/InterledgerAddressParser.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerAddressParser.java
@@ -2,40 +2,19 @@ package org.interledger.core;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
- * An {@link org.interledger.core.InterledgerAddress}es parser.
+ * A parser for validating an {@link InterledgerAddress}.
  */
 final class InterledgerAddressParser {
-
-  static enum Error {
-    ADDRESS_OVERFLOW("Address is too long"),
-    INVALID_SEGMENT("The '%s' segment has an invalid format"),
-    INVALID_SCHEME_PREFIX("The '%s' scheme prefix has an invalid format"),
-    MISSING_SCHEME_PREFIX("Address does not start with a scheme prefix"),
-    SEGMENTS_UNDERFLOW("Destination address has too few segments");
-
-    private String messageFormat;
-
-    private Error(final String messageFormat) {
-      this.messageFormat = messageFormat;
-    }
-
-    public String getMessageFormat() {
-      return messageFormat;
-    }
-  }
 
   private static final int MIN_ADDRESS_LENGTH = 1;
   private static final int MAX_ADDRESS_LENGTH = 1023;
   private static final int DESTINATION_ADDRESS_MIN_SEGMENTS = 2;
-
   private static final String SCHEME_REGEX = "(g|private|example|peer|self|test[1-3]?)";
   private static final String SEGMENT_REGEX = "[a-zA-Z0-9_~-]+";
   private static final String SEPARATOR_CHARACTER = ".";
@@ -44,137 +23,24 @@ final class InterledgerAddressParser {
   private static final String SEGMENT_PREFIX_REGEX = SEGMENT_REGEX + SEPARATOR_REGEX;
   private static final String ADDRESS_LENGTH_BOUNDARIES_REGEX = "(?=^.{" + MIN_ADDRESS_LENGTH + ","
       + MAX_ADDRESS_LENGTH + "}$)";
-
   private static final String ADDRESS_PREFIX_REGEX = ADDRESS_LENGTH_BOUNDARIES_REGEX
       + "^" + SCHEME_PREFIX_REGEX + "(" + SEGMENT_PREFIX_REGEX + ")*$";
   private static final Pattern ADDRESS_PREFIX_PATTERN = Pattern.compile(ADDRESS_PREFIX_REGEX);
-
   private static final String DESTINATION_ADDRESS_REGEX = ADDRESS_LENGTH_BOUNDARIES_REGEX
-      + "^" + SCHEME_PREFIX_REGEX + "(" + SEGMENT_PREFIX_REGEX + ")+"
-      + SEGMENT_REGEX + "$";
+      + "^" + SCHEME_PREFIX_REGEX + "(" + SEGMENT_PREFIX_REGEX + ")+" + SEGMENT_REGEX + "$";
   private static final Pattern DESTINATION_ADDRESS_PATTERN = Pattern.compile(
       DESTINATION_ADDRESS_REGEX
   );
-
   private static final String SCHEME_PREFIX_ONLY_REGEX = "^" + SCHEME_PREFIX_REGEX + "$";
   private static final Pattern SCHEME_PREFIX_ONLY_PATTERN = Pattern.compile(
       SCHEME_PREFIX_ONLY_REGEX
   );
 
   /**
-   * Checks and requires that the specified {@code address} is an address prefix per {@link
-   * InterledgerAddress#isLedgerPrefix()}.
-   *
-   * <p>This method is designed primarily for doing parameter validation in methods and
-   * constructors, as demonstrated below:</p> <blockquote>
-   * <pre>
-   * public Foo(InterledgerAddress bar) {
-   *     this.ledgerPrefix = InterledgerAddress.requireAddressPrefix(bar);
-   * }
-   * </pre>
-   * </blockquote>
-   *
-   * @param address A {@link InterledgerAddress} to check.
-   *
-   * @return {@code address} if its value ends with a dot (.).
-   *
-   * @throws IllegalArgumentException if the supplied Interledger address is not a ledger-prefix.
-   */
-  InterledgerAddress requireAddressPrefix(final InterledgerAddress address) {
-    return checkIsAddressPrefix(address, (ilpAddress) -> "InterledgerAddress must not be null!",
-        (ilpAddress) -> String.format("InterledgerAddress '%s' must be an Address Prefix ending"
-            + " with a dot (.)", ilpAddress.getValue()));
-  }
-
-  /**
-   * Checks and requires that the specified {@code address} is an address prefix per {@link
-   * InterledgerAddress#isLedgerPrefix()}, providing an error message upon invalidation.
-   *
-   * <p>This method is designed primarily for doing parameter validation in methods and
-   * constructors, as demonstrated below:</p> <blockquote>
-   * <pre>
-   * public Foo(InterledgerAddress bar) {
-   *     this.ledgerPrefix = InterledgerAddress.requireAddressPrefix(bar,
-   *         bar + " must be an address prefix);
-   * }
-   * </pre>
-   * </blockquote>
-   *
-   * @param address A {@link InterledgerAddress} to check.
-   * @param errorMessage An error message to output upon invalidation.
-   *
-   * @return {@code address} if its value ends with a dot (.).
-   *
-   * @throws IllegalArgumentException if the supplied Interledger address is not a
-   *     ledger-prefix. Embeds the {@code errorMessage}.
-   */
-  InterledgerAddress requireAddressPrefix(final InterledgerAddress address,
-      final String errorMessage) {
-    Objects.requireNonNull(errorMessage);
-    return checkIsAddressPrefix(address, (ilpAddress) -> errorMessage,
-        (ilpAddress) -> errorMessage);
-  }
-
-  /**
-   * Checks and requires that the specified {@code address} is not an address prefix per
-   * {@link InterledgerAddress#isLedgerPrefix()}.
-   *
-   *
-   * <p>This method is designed primarily for doing parameter validation in methods and
-   * constructors, as demonstrated below:</p> <blockquote>
-   * <pre>
-   * public Foo(InterledgerAddress bar) {
-   *     this.nonLedgerPrefix = InterledgerAddress.requireNotAddressPrefix(bar);
-   * }
-   * </pre>
-   * </blockquote>
-   *
-   * @param address A {@link InterledgerAddress} to check.
-   *
-   * @return {@code address} if its value ends with a dot (.).
-   *
-   * @throws IllegalArgumentException if the supplied Interledger address is not a ledger-prefix.
-   */
-  InterledgerAddress requireNotAddressPrefix(final InterledgerAddress address) {
-    return checkIsNotAddressPrefix(address, (ilpAddress) -> "InterledgerAddress must not be null!",
-        (ilpAddress) -> String.format("InterledgerAddress '%s' must NOT be an Address Prefix ending"
-            + " with a dot (.)", address.getValue()));
-  }
-
-  /**
-   * Checks and requires that the specified {@code address} is not an address prefix per
-   * {@link InterledgerAddress#isLedgerPrefix()}, providing an error message upon invalidation.
-   *
-   *
-   * <p>This method is designed primarily for doing parameter validation in methods and
-   * constructors, as demonstrated below:</p> <blockquote>
-   * <pre>
-   * public Foo(InterledgerAddress bar) {
-   *     this.nonLedgerPrefix = InterledgerAddress.requireNotAddressPrefix(bar,
-   *         bar + " must be a destination address");
-   * }
-   * </pre>
-   * </blockquote>
-   *
-   * @param address A {@link InterledgerAddress} to check.
-   * @param errorMessage An error message to output upon invalidation.
-   *
-   * @return {@code address} if its value ends with a dot (.).
-   *
-   * @throws IllegalArgumentException if the supplied Interledger address is not a
-   *     ledger-prefix. Embeds the {@code errorMessage}.
-   */
-  InterledgerAddress requireNotAddressPrefix(final InterledgerAddress address,
-      final String errorMessage) {
-    Objects.requireNonNull(errorMessage);
-    return checkIsNotAddressPrefix(address, (ilpAddress) -> errorMessage,
-        (ilpAddress) -> errorMessage);
-  }
-
-  /**
    * Validates an ILP address.
-   * 
+   *
    * @param addressString The ILP address to validate
+   *
    * @throws IllegalArgumentException When validation is rejected
    */
   void validate(final String addressString) throws IllegalArgumentException {
@@ -186,34 +52,13 @@ final class InterledgerAddressParser {
 
   /**
    * Determines if an ILP address is a scheme prefix.
-   * 
+   *
    * @param addressString The ILP address to evaluate
+   *
    * @return True if address is a scheme prefix, false otherwise
    */
   boolean isSchemePrefix(final String addressString) {
     return SCHEME_PREFIX_ONLY_PATTERN.matcher(addressString).matches();
-  }
-
-  private InterledgerAddress checkIsAddressPrefix(final InterledgerAddress address,
-      final Function<InterledgerAddress, String> errorMessageIfNullAddress,
-      final Function<InterledgerAddress, String> errorMessageIfNotAddressPrefix) {
-    Objects.requireNonNull(address, errorMessageIfNullAddress.apply(address));
-    if (!address.isLedgerPrefix()) {
-      throw new IllegalArgumentException(errorMessageIfNotAddressPrefix.apply(address));
-    } else {
-      return address;
-    }
-  }
-
-  private InterledgerAddress checkIsNotAddressPrefix(final InterledgerAddress address,
-      final Function<InterledgerAddress, String> errorMessageIfNullAddress,
-      final Function<InterledgerAddress, String> errorMessageIfAddressPrefix) {
-    Objects.requireNonNull(address, errorMessageIfNullAddress.apply(address));
-    if (address.isLedgerPrefix()) {
-      throw new IllegalArgumentException(errorMessageIfAddressPrefix.apply(address));
-    } else {
-      return address;
-    }
   }
 
   private boolean isFullyValid(final String addressString) {
@@ -239,13 +84,15 @@ final class InterledgerAddressParser {
     }
 
     // validates each segment format
-    final List<String> segments = schemeAndSegments.stream().skip(1).collect(Collectors.toList());;
+    final List<String> segments = schemeAndSegments.stream().skip(1).collect(Collectors.toList());
     final int segmentsSize = segments.size();
     final Matcher segmentMatcher = Pattern.compile(SEGMENT_REGEX).matcher("");
-    final Optional<String> invalidSegment = segments.stream().filter(segment -> {
-      segmentMatcher.reset(segment);
-      return !segmentMatcher.matches();
-    }).findFirst();
+    final Optional<String> invalidSegment = segments.stream()
+        .filter(segment -> {
+          segmentMatcher.reset(segment);
+          return !segmentMatcher.matches();
+        })
+        .findFirst();
     if (invalidSegment.isPresent()) {
       return String.format(Error.INVALID_SEGMENT.getMessageFormat(), invalidSegment.get());
     }
@@ -263,6 +110,24 @@ final class InterledgerAddressParser {
 
     // fault: should have found an error cause
     throw new RuntimeException();
+  }
+
+  enum Error {
+    ADDRESS_OVERFLOW("Address is too long"),
+    INVALID_SEGMENT("The '%s' segment has an invalid format"),
+    INVALID_SCHEME_PREFIX("The '%s' scheme prefix has an invalid format"),
+    MISSING_SCHEME_PREFIX("Address does not start with a scheme prefix"),
+    SEGMENTS_UNDERFLOW("Destination address has too few segments");
+
+    private String messageFormat;
+
+    Error(final String messageFormat) {
+      this.messageFormat = messageFormat;
+    }
+
+    public String getMessageFormat() {
+      return messageFormat;
+    }
   }
 
 }

--- a/ilp-core/src/main/java/org/interledger/core/InterledgerAddressParser.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerAddressParser.java
@@ -2,6 +2,7 @@ package org.interledger.core;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -44,6 +45,7 @@ final class InterledgerAddressParser {
    * @throws IllegalArgumentException When validation is rejected
    */
   void validate(final String addressString) throws IllegalArgumentException {
+    Objects.requireNonNull(addressString); // No error-message because this should never happen
     if (isFullyValid(addressString)) {
       return;
     }
@@ -58,6 +60,7 @@ final class InterledgerAddressParser {
    * @return True if address is a scheme prefix, false otherwise
    */
   boolean isSchemePrefix(final String addressString) {
+    Objects.requireNonNull(addressString); // No error-message because this should never happen
     return SCHEME_PREFIX_ONLY_PATTERN.matcher(addressString).matches();
   }
 

--- a/ilp-core/src/test/java/org/interledger/core/InterledgerAddressParserTest.java
+++ b/ilp-core/src/test/java/org/interledger/core/InterledgerAddressParserTest.java
@@ -77,116 +77,6 @@ public class InterledgerAddressParserTest {
   }
 
   @Test
-  public void testRequireAddressPrefix() {
-    assertThat(addressParser.requireAddressPrefix(InterledgerAddress.of("g.")),
-        is(InterledgerAddress.of("g.")));
-    assertThat(addressParser.requireAddressPrefix(InterledgerAddress.of("g.foo.")),
-        is(InterledgerAddress.of("g.foo.")));
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testRequireAddressPrefixWithNullAddress() {
-    try {
-      addressParser.requireAddressPrefix(null);
-    } catch (final NullPointerException e) {
-      assertThat(e.getMessage(), is("InterledgerAddress must not be null!"));
-      throw e;
-    }
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testRequireAddressPrefixWithNullErrorMessage() {
-      addressParser.requireAddressPrefix(InterledgerAddress.of("g."), null);
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testRequireAddressPrefixWithNullAddressAndErrorMessage() {
-    try {
-      addressParser.requireAddressPrefix(null, "An address prefix is mandatory");
-    } catch (final NullPointerException e) {
-      assertThat(e.getMessage(), is("An address prefix is mandatory"));
-      throw e;
-    }
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testRequireAddressPrefixWithNoAddressPrefix() {
-    try {
-      addressParser.requireAddressPrefix(InterledgerAddress.of("g.foo.bar"));
-    } catch (final IllegalArgumentException e) {
-      assertThat(e.getMessage(), is("InterledgerAddress 'g.foo.bar' must be an Address Prefix"
-          + " ending with a dot (.)"));
-      throw e;
-    }
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testRequireAddressPrefixWithNoAddressPrefixAndErrorMessage() {
-    try {
-      addressParser.requireAddressPrefix(InterledgerAddress.of("g.foo.bar"), "An address prefix"
-          + " is mandatory");
-    } catch (final IllegalArgumentException e) {
-      assertThat(e.getMessage(), is("An address prefix is mandatory"));
-      throw e;
-    }
-  }
-
-  @Test
-  public void testRequireNotAddressPrefix() {
-    assertThat(addressParser.requireNotAddressPrefix(InterledgerAddress.of("g.foo.bar")),
-        is(InterledgerAddress.of("g.foo.bar")));
-    assertThat(addressParser.requireNotAddressPrefix(InterledgerAddress.of("g.foo.bar.baz")),
-        is(InterledgerAddress.of("g.foo.bar.baz")));
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testRequireNotAddressPrefixWithNullAddress() {
-    try {
-      addressParser.requireNotAddressPrefix(null);
-    } catch (final NullPointerException e) {
-      assertThat(e.getMessage(), is("InterledgerAddress must not be null!"));
-      throw e;
-    }
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testRequireNotAddressPrefixWithNullErrorMessage() {
-      addressParser.requireNotAddressPrefix(InterledgerAddress.of("g.foo.bar"), null);
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testRequireNotAddressPrefixWithNullAddressAndErrorMessage() {
-    try {
-      addressParser.requireNotAddressPrefix(null, "A destination address is mandatory");
-    } catch (final NullPointerException e) {
-      assertThat(e.getMessage(), is("A destination address is mandatory"));
-      throw e;
-    }
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testRequireNotAddressPrefixWithNoAddressPrefix() {
-    try {
-      addressParser.requireNotAddressPrefix(InterledgerAddress.of("g.foo."));
-    } catch (final IllegalArgumentException e) {
-      assertThat(e.getMessage(), is("InterledgerAddress 'g.foo.' must NOT be an Address"
-          + " Prefix ending with a dot (.)"));
-      throw e;
-    }
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testRequireNotAddressPrefixWithNoAddressPrefixAndErrorMessage() {
-    try {
-      addressParser.requireNotAddressPrefix(InterledgerAddress.of("g.foo."), "A destination"
-          + " address is mandatory");
-    } catch (final IllegalArgumentException e) {
-      assertThat(e.getMessage(), is("A destination address is mandatory"));
-      throw e;
-    }
-  }
-
-  @Test
   public void testValidate() {
     addressParser.validate("self.");
     addressParser.validate("g.");
@@ -225,27 +115,32 @@ public class InterledgerAddressParserTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSchemePrefix_04() {
-    assertValidationErrorThenThrow(".foo", InterledgerAddressParser.Error.INVALID_SCHEME_PREFIX, "");
+    assertValidationErrorThenThrow(".foo", InterledgerAddressParser.Error.INVALID_SCHEME_PREFIX,
+        "");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSchemePrefix_05() {
-    assertValidationErrorThenThrow("gg.", InterledgerAddressParser.Error.INVALID_SCHEME_PREFIX, "gg");
+    assertValidationErrorThenThrow("gg.", InterledgerAddressParser.Error.INVALID_SCHEME_PREFIX,
+        "gg");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSchemePrefix_06() {
-    assertValidationErrorThenThrow(" g.", InterledgerAddressParser.Error.INVALID_SCHEME_PREFIX, " g");
+    assertValidationErrorThenThrow(" g.", InterledgerAddressParser.Error.INVALID_SCHEME_PREFIX,
+        " g");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSchemePrefix_07() {
-    assertValidationErrorThenThrow("g .", InterledgerAddressParser.Error.INVALID_SCHEME_PREFIX, "g ");
+    assertValidationErrorThenThrow("g .", InterledgerAddressParser.Error.INVALID_SCHEME_PREFIX,
+        "g ");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSchemePrefix_08() {
-    assertValidationErrorThenThrow("@@@.", InterledgerAddressParser.Error.INVALID_SCHEME_PREFIX, "@@@");
+    assertValidationErrorThenThrow("@@@.", InterledgerAddressParser.Error.INVALID_SCHEME_PREFIX,
+        "@@@");
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -255,12 +150,14 @@ public class InterledgerAddressParserTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSegment_02() {
-    assertValidationErrorThenThrow("g.\u0000", InterledgerAddressParser.Error.INVALID_SEGMENT, "\u0000");
+    assertValidationErrorThenThrow("g.\u0000", InterledgerAddressParser.Error.INVALID_SEGMENT,
+        "\u0000");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSegment_03() {
-    assertValidationErrorThenThrow("g.\u00E9", InterledgerAddressParser.Error.INVALID_SEGMENT, "\u00E9");
+    assertValidationErrorThenThrow("g.\u00E9", InterledgerAddressParser.Error.INVALID_SEGMENT,
+        "\u00E9");
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -275,12 +172,14 @@ public class InterledgerAddressParserTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSegment_06() {
-    assertValidationErrorThenThrow("g.foo.@.baz", InterledgerAddressParser.Error.INVALID_SEGMENT, "@");
+    assertValidationErrorThenThrow("g.foo.@.baz", InterledgerAddressParser.Error.INVALID_SEGMENT,
+        "@");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSegment_07() {
-    assertValidationErrorThenThrow("g.foo.bar.a@1", InterledgerAddressParser.Error.INVALID_SEGMENT, "a@1");
+    assertValidationErrorThenThrow("g.foo.bar.a@1", InterledgerAddressParser.Error.INVALID_SEGMENT,
+        "a@1");
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -291,7 +190,8 @@ public class InterledgerAddressParserTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSegment_09() {
-    assertValidationErrorThenThrow("g.foo.bar.baz\r\n", InterledgerAddressParser.Error.INVALID_SEGMENT,
+    assertValidationErrorThenThrow("g.foo.bar.baz\r\n",
+        InterledgerAddressParser.Error.INVALID_SEGMENT,
         "baz\r\n");
   }
 
@@ -314,8 +214,8 @@ public class InterledgerAddressParserTest {
       assertThat(e.getMessage(), is(String.format(expectedError.getMessageFormat(), errorParams)));
       throw e;
     } catch (final Exception e) {
-        fail("Should have thrown an IllegalArgumentException");
-        throw e;
+      fail("Should have thrown an IllegalArgumentException");
+      throw e;
     }
   }
 

--- a/ilp-core/src/test/java/org/interledger/core/InterledgerAddressTest.java
+++ b/ilp-core/src/test/java/org/interledger/core/InterledgerAddressTest.java
@@ -4,11 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
-import org.interledger.core.InterledgerAddress;
-
 import org.junit.Test;
-
-import java.net.URI;
 
 /**
  * JUnit tests to test {@link InterledgerAddress}.
@@ -90,7 +86,8 @@ public class InterledgerAddressTest {
   public void testAddressPrefixWithAddressPrefix() {
     final InterledgerAddress destinationAddress = InterledgerAddress.of("g.foo.bob");
     final String additionalDestinationAddress = "boz.";
-    assertThat(destinationAddress.with(additionalDestinationAddress).getValue(), is("g.foo.bob.boz."));
+    assertThat(destinationAddress.with(additionalDestinationAddress).getValue(),
+        is("g.foo.bob.boz."));
   }
 
   /**
@@ -110,7 +107,8 @@ public class InterledgerAddressTest {
   public void testDestinationAddressWithDestinationAddress() {
     final InterledgerAddress destinationAddress = InterledgerAddress.of("g.foo.bob");
     final String additionalDestinationAddress = "boz";
-    assertThat(destinationAddress.with(additionalDestinationAddress).getValue(), is("g.foo.bob.boz"));
+    assertThat(destinationAddress.with(additionalDestinationAddress).getValue(),
+        is("g.foo.bob.boz"));
   }
 
   /**
@@ -120,7 +118,8 @@ public class InterledgerAddressTest {
   public void testDestinationAddressWithAddressPrefix() {
     final InterledgerAddress destinationAddress = InterledgerAddress.of("g.foo.bob");
     final String additionalDestinationAddress = "boz.";
-    assertThat(destinationAddress.with(additionalDestinationAddress).getValue(), is("g.foo.bob.boz."));
+    assertThat(destinationAddress.with(additionalDestinationAddress).getValue(),
+        is("g.foo.bob.boz."));
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -274,8 +273,7 @@ public class InterledgerAddressTest {
       InterledgerAddress.requireAddressPrefix(null);
       fail("Should have thrown an NullPointerException!");
     } catch (NullPointerException e) {
-      assertThat(e.getMessage(),
-          is("InterledgerAddress must not be null!"));
+      assertThat(e.getMessage(), is("address must not be null!"));
       throw e;
     }
   }
@@ -290,8 +288,7 @@ public class InterledgerAddressTest {
       InterledgerAddress.requireAddressPrefix(null, "An address prefix is mandatory");
       fail("Should have thrown an NullPointerException!");
     } catch (NullPointerException e) {
-      assertThat(e.getMessage(),
-          is("An address prefix is mandatory"));
+      assertThat(e.getMessage(), is("address must not be null!"));
       throw e;
     }
   }
@@ -351,8 +348,7 @@ public class InterledgerAddressTest {
       InterledgerAddress.requireNotAddressPrefix(null);
       fail("Should have thrown an NullPointerException!");
     } catch (NullPointerException e) {
-      assertThat(e.getMessage(),
-          is("InterledgerAddress must not be null!"));
+      assertThat(e.getMessage(), is("address must not be null!"));
       throw e;
     }
   }
@@ -367,8 +363,17 @@ public class InterledgerAddressTest {
       InterledgerAddress.requireNotAddressPrefix(null, "A destination address is mandatory");
       fail("Should have thrown an NullPointerException!");
     } catch (NullPointerException e) {
-      assertThat(e.getMessage(),
-          is("A destination address is mandatory"));
+      assertThat(e.getMessage(), is("address must not be null!"));
+      throw e;
+    }
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testRequireNotAddressPrefixWithNullErrorMessage() {
+    try {
+      InterledgerAddress.requireNotAddressPrefix(InterledgerAddress.of("g.foo.bar"), null);
+      fail();
+    } catch (NullPointerException e) {
       throw e;
     }
   }
@@ -406,6 +411,14 @@ public class InterledgerAddressTest {
     }
   }
 
+  @Test
+  public void testRequireNotAddressPrefix() {
+    assertThat(InterledgerAddress.requireNotAddressPrefix(InterledgerAddress.of("g.foo.bar")),
+        is(InterledgerAddress.of("g.foo.bar")));
+    assertThat(InterledgerAddress.requireNotAddressPrefix(InterledgerAddress.of("g.foo.bar.baz")),
+        is(InterledgerAddress.of("g.foo.bar.baz")));
+  }
+
   /**
    * Assert that a non-address prefix passes the {@link InterledgerAddress#requireNotAddressPrefix(InterledgerAddress)}
    * check.
@@ -418,5 +431,41 @@ public class InterledgerAddressTest {
 
     assertThat(checkedAddressPrefix, is(controlPrefix));
   }
+
+  @Test
+  public void testRequireAddressPrefix() {
+    assertThat(InterledgerAddress.requireAddressPrefix(InterledgerAddress.of("g.")),
+        is(InterledgerAddress.of("g.")));
+    assertThat(InterledgerAddress.requireAddressPrefix(InterledgerAddress.of("g.foo.")),
+        is(InterledgerAddress.of("g.foo.")));
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testRequireAddressPrefixWithNullErrorMessage() {
+    InterledgerAddress.requireAddressPrefix(InterledgerAddress.of("g."), null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testRequireAddressPrefixWithNullAddressAndErrorMessage() {
+    try {
+      InterledgerAddress.requireAddressPrefix(null, "An address prefix is mandatory");
+    } catch (final NullPointerException e) {
+      assertThat(e.getMessage(), is("address must not be null!"));
+      throw e;
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testRequireAddressPrefixWithNoAddressPrefixAndErrorMessage() {
+    try {
+      InterledgerAddress.requireAddressPrefix(
+          InterledgerAddress.of("g.foo.bar"), "An address prefix is mandatory"
+      );
+    } catch (final IllegalArgumentException e) {
+      assertThat(e.getMessage(), is("An address prefix is mandatory"));
+      throw e;
+    }
+  }
+
 
 }


### PR DESCRIPTION
_**NOTE: This PR incorporates #129, which is purely Javadoc and formatting, so it might be easier to review that PR first before looking at this one.**_

This PR simplifies the AddressParser by restoring all null-input invariant checks back into the InterledgerAddress. By not allowing `null` into the AddressParser by design, it no longer must account for multi-error conditions related to `null` values, and can focus on its core purpose, which is validity checks on non-null input.

A more detailed rationale:
1. AddressParser should not be doing any null-check enforcement, because InterledgerAddress itself should enforce the non-use of `null` as a developer error. In other words, there is a distinction between `null` making its way into an `InterledgerAddress` and some non-null String input that simply doesn't rise to the bar enforced by IL-RFC-15.

2. Once the parser becomes responsible for address content and formation checking only, it is somewhat simplified. The 4 `InterledgerAddress#require` methods no longer need to delegate to `AddressParser` because the logic is not complicated enough to justify the delegation.

3. Once moved back into InterledgerAddress, these implementations do not share any code between themselves (i.e., the two `requireAddressPrefix` methods are slightly duplicative, and the two `requireNotAddressPrefix` methods are also slightly duplicative). In each case, this is for performance reasons -- for example, we might be tempted to have `requireAddressPrefix(address)` delegate to `requireAddressPrefix(address, message)` with a default `message`. However, the happy-path usage of this call-chain would compute a new String for the error message, which would be different for every check of every ILP address in a system, and 99% of the time this String allocation would be unnecessary. In other words, we only want to assemble an error-string (with an ILP address inside) _if_ the method will actually throw an Exception. Thus, we optimize for the happy-path and duplicate the `if` check.

@pascalav @adrianhopebailie 
