### PR TITLE
Misc Packet Cleanup

### DIFF
--- a/btp-core/src/main/java/org/interledger/btp/BtpSubProtocolContentType.java
+++ b/btp-core/src/main/java/org/interledger/btp/BtpSubProtocolContentType.java
@@ -9,9 +9,9 @@ package org.interledger.btp;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,14 +23,15 @@ package org.interledger.btp;
 import static java.lang.String.format;
 
 public enum BtpSubProtocolContentType {
-  MIME_APPLICATION_OCTET_STREAM(0),
-  MIME_TEXT_PLAIN_UTF8(1),
-  MIME_APPLICATION_JSON(2),;
+  MIME_APPLICATION_OCTET_STREAM((short) 0),
+  MIME_TEXT_PLAIN_UTF8((short) 1),
+  MIME_APPLICATION_JSON((short) 2),
+  ;
 
-  private final int code;
+  private final short code;
 
 
-  BtpSubProtocolContentType(int code) {
+  BtpSubProtocolContentType(short code) {
     this.code = code;
   }
 
@@ -38,9 +39,10 @@ public enum BtpSubProtocolContentType {
    * Get a new {@link BtpSubProtocolContentType} from the given code.
    *
    * @param code a type code
+   *
    * @return an instance of {@link BtpSubProtocolContentType}
    */
-  public static BtpSubProtocolContentType fromCode(int code) {
+  public static BtpSubProtocolContentType fromCode(short code) {
 
     switch (code) {
       case 0:
@@ -50,11 +52,12 @@ public enum BtpSubProtocolContentType {
       case 2:
         return MIME_APPLICATION_JSON;
       default:
-        throw new IllegalArgumentException(format("Unknown BTP Sub-Protocol Content Type: %s", code));
+        throw new IllegalArgumentException(
+            format("Unknown BTP Sub-Protocol Content Type: %s", code));
     }
   }
 
-  public int getCode() {
+  public short getCode() {
     return this.code;
   }
 }

--- a/btp-core/src/test/java/org/interledger/btp/BtpSubProtocolContentTypeTest.java
+++ b/btp-core/src/test/java/org/interledger/btp/BtpSubProtocolContentTypeTest.java
@@ -9,9 +9,9 @@ package org.interledger.btp;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,11 +37,11 @@ public class BtpSubProtocolContentTypeTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void fromNegativeCode() {
-    BtpSubProtocolContentType.fromCode(-1);
+    BtpSubProtocolContentType.fromCode((short) -1);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void fromInvalidCode() {
-    BtpSubProtocolContentType.fromCode(Integer.MAX_VALUE);
+    BtpSubProtocolContentType.fromCode(Short.MAX_VALUE);
   }
 }

--- a/ilp-core-codecs/src/main/java/org/interledger/core/asn/codecs/AsnInterledgerAddressPrefixCodec.java
+++ b/ilp-core-codecs/src/main/java/org/interledger/core/asn/codecs/AsnInterledgerAddressPrefixCodec.java
@@ -1,8 +1,8 @@
-package org.interledger.core;
+package org.interledger.core.asn.codecs;
 
 /*-
  * ========================LICENSE_START=================================
- * Interledger Core
+ * Interledger Core Codecs
  * %%
  * Copyright (C) 2017 - 2018 Hyperledger and its contributors
  * %%
@@ -20,36 +20,24 @@ package org.interledger.core;
  * =========================LICENSE_END==================================
  */
 
-import org.interledger.annotations.Immutable;
+import org.interledger.core.InterledgerAddressPrefix;
+import org.interledger.encoding.asn.codecs.AsnIA5StringBasedObjectCodec;
+import org.interledger.encoding.asn.codecs.AsnSizeConstraint;
 
-import org.immutables.value.Value.Default;
+public class AsnInterledgerAddressPrefixCodec extends
+    AsnIA5StringBasedObjectCodec<InterledgerAddressPrefix> {
 
-public interface InterledgerFulfillPacket extends InterledgerPacket {
-
-  /**
-   * Get the default builder.
-   *
-   * @return a {@link InterledgerFulfillPacketBuilder} instance.
-   */
-  static InterledgerFulfillPacketBuilder builder() {
-    return new InterledgerFulfillPacketBuilder();
+  public AsnInterledgerAddressPrefixCodec() {
+    super(new AsnSizeConstraint(1, 1023));
   }
 
-  /**
-   * Accessor for the fulfillment portion of this packet.
-   *
-   * @return An instance of {@link InterledgerFulfillment}.
-   */
-  InterledgerFulfillment getFulfillment();
-
-  @Immutable
-  abstract class AbstractInterledgerFulfillPacket implements InterledgerFulfillPacket {
-
-    @Override
-    @Default
-    public byte[] getData() {
-      return new byte[0];
-    }
+  @Override
+  public InterledgerAddressPrefix decode() {
+    return InterledgerAddressPrefix.of(getCharString());
   }
 
+  @Override
+  public void encode(InterledgerAddressPrefix value) {
+    setCharString(value.getValue());
+  }
 }

--- a/ilp-core-codecs/src/main/java/org/interledger/core/asn/framework/InterledgerCodecContextFactory.java
+++ b/ilp-core-codecs/src/main/java/org/interledger/core/asn/framework/InterledgerCodecContextFactory.java
@@ -21,6 +21,7 @@ package org.interledger.core.asn.framework;
  */
 
 import org.interledger.core.InterledgerAddress;
+import org.interledger.core.InterledgerAddressPrefix;
 import org.interledger.core.InterledgerCondition;
 import org.interledger.core.InterledgerErrorCode;
 import org.interledger.core.InterledgerFulfillPacket;
@@ -31,6 +32,7 @@ import org.interledger.core.InterledgerRejectPacket;
 import org.interledger.core.asn.codecs.AsnConditionCodec;
 import org.interledger.core.asn.codecs.AsnFulfillmentCodec;
 import org.interledger.core.asn.codecs.AsnInterledgerAddressCodec;
+import org.interledger.core.asn.codecs.AsnInterledgerAddressPrefixCodec;
 import org.interledger.core.asn.codecs.AsnInterledgerErrorCodeCodec;
 import org.interledger.core.asn.codecs.AsnInterledgerFulfillPacketCodec;
 import org.interledger.core.asn.codecs.AsnInterledgerPacketCodec;
@@ -65,6 +67,8 @@ public class InterledgerCodecContextFactory {
         .register(InterledgerFulfillment.class, AsnFulfillmentCodec::new,
             new AsnOctetStringOerSerializer())
         .register(InterledgerAddress.class, AsnInterledgerAddressCodec::new,
+            new AsnCharStringOerSerializer())
+        .register(InterledgerAddressPrefix.class, AsnInterledgerAddressPrefixCodec::new,
             new AsnCharStringOerSerializer())
         .register(InterledgerErrorCode.class, AsnInterledgerErrorCodeCodec::new,
             new AsnCharStringOerSerializer())

--- a/ilp-core-codecs/src/test/java/org/interledger/core/asn/codecs/AsnInterledgerAddressCodecTest.java
+++ b/ilp-core-codecs/src/test/java/org/interledger/core/asn/codecs/AsnInterledgerAddressCodecTest.java
@@ -1,0 +1,35 @@
+package org.interledger.core.asn.codecs;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import org.interledger.core.InterledgerAddress;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link AsnInterledgerAddressCodec}.
+ */
+public class AsnInterledgerAddressCodecTest {
+
+  private static final String G_FOO = "g.foo";
+  private AsnInterledgerAddressCodec codec;
+
+  @Before
+  public void setUp() {
+    codec = new AsnInterledgerAddressCodec();
+    codec.setCharString(G_FOO);
+  }
+
+  @Test
+  public void decode() {
+    assertThat(codec.decode(), is(InterledgerAddress.of(G_FOO)));
+  }
+
+  @Test
+  public void encode() {
+    codec.encode(InterledgerAddress.of(G_FOO));
+    assertThat(codec.getCharString(), is(G_FOO));
+  }
+}

--- a/ilp-core-codecs/src/test/java/org/interledger/core/asn/codecs/AsnInterledgerAddressPrefixCodecTest.java
+++ b/ilp-core-codecs/src/test/java/org/interledger/core/asn/codecs/AsnInterledgerAddressPrefixCodecTest.java
@@ -1,0 +1,35 @@
+package org.interledger.core.asn.codecs;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import org.interledger.core.InterledgerAddressPrefix;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link AsnInterledgerAddressPrefixCodec}.
+ */
+public class AsnInterledgerAddressPrefixCodecTest {
+
+  private static final String G = "g";
+  private AsnInterledgerAddressPrefixCodec codec;
+
+  @Before
+  public void setUp() {
+    codec = new AsnInterledgerAddressPrefixCodec();
+    codec.setCharString(G);
+  }
+
+  @Test
+  public void decode() {
+    assertThat(codec.decode(), is(InterledgerAddressPrefix.of(G)));
+  }
+
+  @Test
+  public void encode() {
+    codec.encode(InterledgerAddressPrefix.of(G));
+    assertThat(codec.getCharString(), is(G));
+  }
+}

--- a/ilp-core/src/main/java/org/interledger/core/InterledgerAddress.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerAddress.java
@@ -315,15 +315,23 @@ public interface InterledgerAddress {
       defaults = @Value.Immutable(intern = true))
   abstract class AbstractInterledgerAddress implements InterledgerAddress {
 
+    static final String SEPARATOR_REGEX = "[.]";
+
+    private static final String SCHEME_REGEX = "(g|private|example|peer|self|test[1-3]?)";
+    static final Pattern SCHEME_PATTERN = Pattern.compile(SCHEME_REGEX);
+
     private static final String VALID_ADDRESS_REGEX
         = "(?=^.{1,1023}$)^(g|private|example|peer|self|test[1-3]?|local)([.][a-zA-Z0-9_~-]+)+$";
     private static final Pattern VALID_ADDRESS_PATTERN = Pattern.compile(VALID_ADDRESS_REGEX);
 
     private static final int ADDRESS_MIN_SEGMENTS = 2;
-    private static final String SCHEME_REGEX = "(g|private|example|peer|self|test[1-3]?)";
+
     private static final String SEGMENT_REGEX = "[a-zA-Z0-9_~-]+";
-    private static final String SEPARATOR_REGEX = "[.]";
+    static final Pattern SEGMENT_PATTERN = Pattern.compile(SEGMENT_REGEX);
+
     private static final String ADDRESS_LENGTH_BOUNDARIES_REGEX = "(?=^.{1,1023}$)";
+    private static final Pattern ADDRESS_LENGTH_BOUNDARIES_PATTERN = Pattern
+        .compile(ADDRESS_LENGTH_BOUNDARIES_REGEX);
 
     /**
      * Validation of an ILP address occurs via Regex, so we don't need to aggressivly compute this
@@ -373,14 +381,14 @@ public interface InterledgerAddress {
       );
       // validates scheme prefix format
       final String schemePrefix = schemeAndSegments.get(0);
-      if (!Pattern.compile(SCHEME_REGEX).matcher(schemePrefix).matches()) {
+      if (!SCHEME_PATTERN.matcher(schemePrefix).matches()) {
         return String.format(Error.INVALID_SCHEME_PREFIX.getMessageFormat(), schemePrefix);
       }
 
       // validates each segment format
       final List<String> segments = schemeAndSegments.stream().skip(1).collect(Collectors.toList());
       final int segmentsSize = segments.size();
-      final Matcher segmentMatcher = Pattern.compile(SEGMENT_REGEX).matcher("");
+      final Matcher segmentMatcher = SEGMENT_PATTERN.matcher("");
       final Optional<String> invalidSegment = segments.stream()
           .filter(segment -> {
             segmentMatcher.reset(segment);
@@ -397,8 +405,7 @@ public interface InterledgerAddress {
       }
 
       // validates max address length
-      if (!Pattern.compile(ADDRESS_LENGTH_BOUNDARIES_REGEX).matcher(invalidAddressString)
-          .matches()) {
+      if (!ADDRESS_LENGTH_BOUNDARIES_PATTERN.matcher(invalidAddressString).matches()) {
         return Error.ADDRESS_OVERFLOW.getMessageFormat();
       }
 

--- a/ilp-core/src/main/java/org/interledger/core/InterledgerAddress.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerAddress.java
@@ -167,8 +167,8 @@ public interface InterledgerAddress {
    *
    * <p>If this address has only a single segment after the allocation scheme, then this method
    * returns {@link Optional#empty()}. Otherwise, this method returns a new {@link
-   * InterledgerAddress} containing the characters inside of {@link #getValue()}, up-to but excluding
-   * last period.</p>
+   * InterledgerAddress} containing the characters inside of {@link #getValue()}, up-to but
+   * excluding last period.</p>
    *
    * <p>For example, calling this method on an address <tt>g.example.alice</tt> would yield a new
    * address containing <tt>g.example</tt>. However, calling this method on an address like
@@ -209,6 +209,16 @@ public interface InterledgerAddress {
    */
   interface AllocationScheme {
 
+    AllocationScheme GLOBAL = AllocationScheme.of("g");
+    AllocationScheme PRIVATE = AllocationScheme.of("private");
+    AllocationScheme EXAMPLE = AllocationScheme.of("example");
+    AllocationScheme PEER = AllocationScheme.of("peer");
+    AllocationScheme SELF = AllocationScheme.of("self");
+    AllocationScheme TEST = AllocationScheme.of("test");
+    AllocationScheme TEST1 = AllocationScheme.of("test1");
+    AllocationScheme TEST2 = AllocationScheme.of("test2");
+    AllocationScheme TEST3 = AllocationScheme.of("test3");
+
     /**
      * Constructor to allow quick construction from a {@link String} representation of an ILP
      * address allocation scheme.
@@ -220,7 +230,7 @@ public interface InterledgerAddress {
      * @throws NullPointerException if {@code value} is <tt>null</tt>.
      */
     static AllocationScheme of(final String value) {
-      Objects.requireNonNull(value, "getValue must not be null!");
+      Objects.requireNonNull(value, "value must not be null!");
       return builder().value(value).build();
     }
 
@@ -233,7 +243,12 @@ public interface InterledgerAddress {
       return new AllocationSchemeBuilder();
     }
 
-    String value();
+    /**
+     * Accessor for the value of this {@link InterledgerAddress}.
+     *
+     * @return A {@link String} with the value of this address.
+     */
+    String getValue();
 
     /**
      * <p>An implementation of {@link AllocationScheme} that enforces allowed
@@ -260,9 +275,9 @@ public interface InterledgerAddress {
        */
       @Value.Check
       void check() {
-        if (!SCHEME_PREFIX_ONLY_PATTERN.matcher(value()).matches()) {
+        if (!SCHEME_PREFIX_ONLY_PATTERN.matcher(getValue()).matches()) {
           throw new IllegalArgumentException(
-              String.format(Error.INVALID_SCHEME_PREFIX.getMessageFormat(), value())
+              String.format(Error.INVALID_SCHEME_PREFIX.getMessageFormat(), getValue())
           );
         }
       }

--- a/ilp-core/src/main/java/org/interledger/core/InterledgerAddressPrefix.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerAddressPrefix.java
@@ -38,10 +38,10 @@ public interface InterledgerAddressPrefix {
    *
    * @return an {@link InterledgerAddress} instance.
    *
-   * @throws NullPointerException if {@code getValue} is <tt>null</tt>.
+   * @throws NullPointerException if {@code value} is <tt>null</tt>.
    */
   static InterledgerAddressPrefix of(final String value) {
-    Objects.requireNonNull(value, "getValue must not be null!");
+    Objects.requireNonNull(value, "value must not be null!");
     return builder().value(value).build();
   }
 
@@ -77,7 +77,7 @@ public interface InterledgerAddressPrefix {
   }
 
   /**
-   * <p>Accessor for this address's getValue as a non-null {@link String}. For example:
+   * <p>Accessor for this address's value as a non-null {@link String}. For example:
    * <code>us.usd.bank.account</code></p>
    *
    * @return A {@link String} representation of this Interledger address.
@@ -181,10 +181,10 @@ public interface InterledgerAddressPrefix {
   }
 
   /**
-   * <p>An implementation of {@link InterledgerAddress} that enforces allowed getValue per
+   * <p>An implementation of {@link InterledgerAddress} that enforces allowed value per
    * RFC-15.</p>
    *
-   * <p>This immutable is interned because it only holds a {@link String} getValue, which itself is
+   * <p>This immutable is interned because it only holds a {@link String} value, which itself is
    * interned via the Java String pool.</p>
    */
   @Value.Immutable
@@ -207,7 +207,7 @@ public interface InterledgerAddressPrefix {
     private static final String ADDRESS_LENGTH_BOUNDARIES_REGEX = "(?=^.{1,1021}$)";
 
     /**
-     * Precondition enforcer that ensures the getValue is a valid Interledger Address.
+     * Precondition enforcer that ensures the value is a valid Interledger Address.
      *
      * @see "https://github.com/interledger/rfcs/blob/master/0015-ilp-addresses/0015-ilp-addresses.md"
      */

--- a/ilp-core/src/main/java/org/interledger/core/InterledgerAddressPrefix.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerAddressPrefix.java
@@ -1,0 +1,298 @@
+package org.interledger.core;
+
+import org.interledger.core.InterledgerAddress.AllocationScheme;
+
+import org.immutables.value.Value;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * <p>Represents a prefix for an {@link InterledgerAddress}. This class differs only slightly from
+ * {@link InterledgerAddress} in that is allows any valid Interledger address as well as allocation
+ * schemes, whereas {@link InterledgerAddress} requires both an {@link AllocationScheme} as well as
+ * a segment in order to be valid.</p>
+ */
+public interface InterledgerAddressPrefix {
+
+  // Prefixes for all Allocation Schemes.
+  InterledgerAddressPrefix GLOBAL = InterledgerAddressPrefix.from(AllocationScheme.GLOBAL);
+  InterledgerAddressPrefix PRIVATE = InterledgerAddressPrefix.from(AllocationScheme.PRIVATE);
+  InterledgerAddressPrefix EXAMPLE = InterledgerAddressPrefix.from(AllocationScheme.EXAMPLE);
+  InterledgerAddressPrefix PEER = InterledgerAddressPrefix.from(AllocationScheme.PEER);
+  InterledgerAddressPrefix SELF = InterledgerAddressPrefix.from(AllocationScheme.SELF);
+  InterledgerAddressPrefix TEST = InterledgerAddressPrefix.from(AllocationScheme.TEST);
+  InterledgerAddressPrefix TEST1 = InterledgerAddressPrefix.from(AllocationScheme.TEST1);
+  InterledgerAddressPrefix TEST2 = InterledgerAddressPrefix.from(AllocationScheme.TEST2);
+  InterledgerAddressPrefix TEST3 = InterledgerAddressPrefix.from(AllocationScheme.TEST3);
+
+  /**
+   * Constructor to allow quick construction from a {@link String}.
+   *
+   * @param value String representation of an Interledger Address
+   *
+   * @return an {@link InterledgerAddress} instance.
+   *
+   * @throws NullPointerException if {@code getValue} is <tt>null</tt>.
+   */
+  static InterledgerAddressPrefix of(final String value) {
+    Objects.requireNonNull(value, "getValue must not be null!");
+    return builder().value(value).build();
+  }
+
+  /**
+   * Convert from an {@link InterledgerAddress} into an {@link InterledgerAddressPrefix}.
+   *
+   * @param interledgerAddress An {@link InterledgerAddress} to convert from.
+   *
+   * @return A corresponding {@link InterledgerAddressPrefix}.
+   */
+  static InterledgerAddressPrefix from(final InterledgerAddress interledgerAddress) {
+    return builder().value(interledgerAddress.getValue()).build();
+  }
+
+  /**
+   * Convert from an {@link AllocationScheme} into an {@link InterledgerAddressPrefix}.
+   *
+   * @param allocationScheme An {@link AllocationScheme} to convert from.
+   *
+   * @return A corresponding {@link InterledgerAddressPrefix}.
+   */
+  static InterledgerAddressPrefix from(final AllocationScheme allocationScheme) {
+    return builder().value(allocationScheme.getValue()).build();
+  }
+
+  /**
+   * <p>Construct a default builder.</p>
+   *
+   * @return An {@link InterledgerAddressBuilder} instance.
+   */
+  static InterledgerAddressPrefixBuilder builder() {
+    return new InterledgerAddressPrefixBuilder();
+  }
+
+  /**
+   * <p>Accessor for this address's getValue as a non-null {@link String}. For example:
+   * <code>us.usd.bank.account</code></p>
+   *
+   * @return A {@link String} representation of this Interledger address.
+   */
+  String getValue();
+
+  /**
+   * <p>Tests if this InterledgerAddress starts with the specified {@code addressSegment}.</p>
+   *
+   * @param addressSegment An {@link String} prefix to compare against.
+   *
+   * @return {@code true} if this InterledgerAddress begins with the specified prefix.
+   */
+  @SuppressWarnings("unused")
+  default boolean startsWith(final String addressSegment) {
+    Objects.requireNonNull(addressSegment, "addressSegment must not be null!");
+    return this.getValue().startsWith(addressSegment);
+  }
+
+  /**
+   * <p>Tests if this InterledgerAddress starts with the specified {@code addressPrefix}.</p>
+   *
+   * @param addressPrefix An {@link InterledgerAddress} prefix to compare against.
+   *
+   * @return {@code true} if the supplied {@code addressPrefix} begins with the specified prefix.
+   */
+  @SuppressWarnings("unused")
+  default boolean startsWith(final InterledgerAddressPrefix addressPrefix) {
+    Objects.requireNonNull(addressPrefix, "addressPrefix must not be null!");
+    return this.getValue().startsWith(addressPrefix.getValue());
+  }
+
+  /**
+   * <p>Return a new {@link InterledgerAddress} by suffixing the supplied {@code addressSegment}
+   * onto the current address.</p>
+   *
+   * @param addressSegment A {@link String} to be appended to this address as an additional
+   *                       segment.
+   *
+   * @return A new instance representing the original address with a newly specified final segment.
+   */
+  default InterledgerAddressPrefix with(final String addressSegment) {
+    Objects.requireNonNull(addressSegment, "addressSegment must not be null!");
+
+    // `+` operator uses StringBuilder internally, so for small numbers of appends, `+` is
+    // equivalent in performance, but provides better code readability.
+    return InterledgerAddressPrefix.of(this.getValue() + "." + addressSegment);
+  }
+
+  /**
+   * <p>Return this address's prefix.</p>
+   *
+   * <p>If this address has only a single segment after the allocation scheme, then this method
+   * returns {@link Optional#empty()}. Otherwise, this method returns a new {@link
+   * InterledgerAddress} containing the characters inside of {@link #getValue()}, up-to but
+   * excluding last period.</p>
+   *
+   * <p>For example, calling this method on an address <tt>g.example.alice</tt> would yield a new
+   * address containing <tt>g.example</tt>. However, calling this method on an address like
+   * <tt>g.example</tt> would yield {@link Optional#empty()}.</p>
+   *
+   * @return An optionally present parent-prefix as an {@link InterledgerAddress}.
+   */
+  default Optional<InterledgerAddressPrefix> getPrefix() {
+    // An address will always contain at least one period (.), so we can always
+    final String value = getValue();
+    final boolean hasDot = value.contains(".");
+    if (hasDot) {
+      return Optional.of(
+          InterledgerAddressPrefix.builder()
+              .value(value.substring(0, value.lastIndexOf(".")))
+              .build()
+      );
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * <p>Determines if this ILP Address has a parent-prefix.</p>
+   *
+   * @return {@code true} if this address has more than two segments after the allocation scheme.
+   *     Otherwise return {@code false}.
+   */
+  @SuppressWarnings("unused")
+  default boolean hasPrefix() {
+    return getPrefix().isPresent();
+  }
+
+  /**
+   * Compute the root-prefix of the supplied {@code address}. If this prefix is already a
+   * root-prefix (i.e., an AllocationScheme) then this prefix is returned.
+   *
+   * @return An {@link InterledgerAddressPrefix} representing the root prefix for the supplied
+   *     Interledger address.
+   */
+  default InterledgerAddressPrefix getRootPrefix() {
+    return this.getPrefix()
+        .map(InterledgerAddressPrefix::getRootPrefix)
+        .orElse(this);
+  }
+
+  /**
+   * <p>An implementation of {@link InterledgerAddress} that enforces allowed getValue per
+   * RFC-15.</p>
+   *
+   * <p>This immutable is interned because it only holds a {@link String} getValue, which itself is
+   * interned via the Java String pool.</p>
+   */
+  @Value.Immutable
+  @Value.Style(
+      typeBuilder = "*Builder",
+      visibility = Value.Style.ImplementationVisibility.PRIVATE,
+      builderVisibility = Value.Style.BuilderVisibility.PUBLIC,
+      defaults = @Value.Immutable(intern = true))
+  abstract class AbstractInterledgerAddressPrefix implements InterledgerAddressPrefix {
+
+    private static final String VALID_ADDRESS_PREFIX_REGEX
+        = "(?=^.{1,1023}$)^(g|private|example|peer|self|test[1-3]?|local)([.][a-zA-Z0-9_~-]+)*$";
+    private static final Pattern VALID_ADDRESS_PATTERN = Pattern
+        .compile(VALID_ADDRESS_PREFIX_REGEX);
+
+    private static final int ADDRESS_MIN_SEGMENTS = 1;
+    private static final String SCHEME_REGEX = "(g|private|example|peer|self|test[1-3]?)";
+    private static final String SEGMENT_REGEX = "[a-zA-Z0-9_~-]+";
+    private static final String SEPARATOR_REGEX = "[.]";
+    private static final String ADDRESS_LENGTH_BOUNDARIES_REGEX = "(?=^.{1,1021}$)";
+
+    /**
+     * Precondition enforcer that ensures the getValue is a valid Interledger Address.
+     *
+     * @see "https://github.com/interledger/rfcs/blob/master/0015-ilp-addresses/0015-ilp-addresses.md"
+     */
+    @Value.Check
+    void check() {
+      if (!VALID_ADDRESS_PATTERN.matcher(getValue()).matches()) {
+        // For performance reasons, we only do we do deeper introspection of the error if the input
+        // fails the VALID_ADDRESS_PATTERN check.
+        throw new IllegalArgumentException(getFirstInvalidityCause(getValue()));
+      }
+    }
+
+    /**
+     * Inspect an invalid Address String and determine the cause.
+     *
+     * @param invalidAddressString A {@link String} containing an invalid Interledger Address.
+     *
+     * @return An error String.
+     */
+    private String getFirstInvalidityCause(final String invalidAddressString) {
+      // validate no trailing period.
+      if (invalidAddressString.endsWith(".")) {
+        return Error.ILLEGAL_ENDING.getMessageFormat();
+      }
+
+      final List<String> schemeAndSegments = Arrays.asList(
+          invalidAddressString.split(SEPARATOR_REGEX, -1)
+      );
+      // validates scheme prefix format
+      final String schemePrefix = schemeAndSegments.get(0);
+      if (!Pattern.compile(SCHEME_REGEX).matcher(schemePrefix).matches()) {
+        return String.format(Error.INVALID_SCHEME_PREFIX.getMessageFormat(), schemePrefix);
+      }
+
+      // validates each segment format
+      final List<String> segments = schemeAndSegments.stream().skip(1).collect(Collectors.toList());
+      final int segmentsSize = segments.size();
+      final Matcher segmentMatcher = Pattern.compile(SEGMENT_REGEX).matcher("");
+      final Optional<String> invalidSegment = segments.stream()
+          .filter(segment -> {
+            segmentMatcher.reset(segment);
+            return !segmentMatcher.matches();
+          })
+          .findFirst();
+      if (invalidSegment.isPresent()) {
+        return String.format(Error.INVALID_SEGMENT.getMessageFormat(), invalidSegment.get());
+      }
+
+      // validates the minimum number of segments for a destination address
+      if (segmentsSize < ADDRESS_MIN_SEGMENTS) {
+        return Error.SEGMENTS_UNDERFLOW.getMessageFormat();
+      }
+
+      // validates max address length
+      if (!Pattern.compile(ADDRESS_LENGTH_BOUNDARIES_REGEX).matcher(invalidAddressString)
+          .matches()) {
+        return Error.ADDRESS_OVERFLOW.getMessageFormat();
+      }
+
+      // fault: should have found an error cause
+      throw new IllegalArgumentException(String.format(
+          "Unable to find error for invalid InterledgerAddress: %s", invalidAddressString
+      ));
+    }
+
+    /**
+     * A potential error that might be emitted if an invalid Interledger Address is encountered.
+     */
+    public enum Error {
+      INVALID_SCHEME_PREFIX("The '%s' AllocationScheme is invalid!"),
+      ILLEGAL_ENDING("An InterledgerAddressPrefix MUST not end with a period (.) character"),
+      ADDRESS_OVERFLOW("InterledgerAddressPrefix is too long"),
+      INVALID_SEGMENT("The '%s' segment has an invalid format"),
+      SEGMENTS_UNDERFLOW("InterledgerAddressPrefix has too few segments");
+
+      private String messageFormat;
+
+      Error(final String messageFormat) {
+        this.messageFormat = messageFormat;
+      }
+
+      public String getMessageFormat() {
+        return messageFormat;
+      }
+    }
+  }
+
+}

--- a/ilp-core/src/main/java/org/interledger/core/InterledgerAddressPrefix.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerAddressPrefix.java
@@ -1,5 +1,9 @@
 package org.interledger.core;
 
+import static org.interledger.core.InterledgerAddress.AbstractInterledgerAddress.SCHEME_PATTERN;
+import static org.interledger.core.InterledgerAddress.AbstractInterledgerAddress.SEGMENT_PATTERN;
+import static org.interledger.core.InterledgerAddress.AbstractInterledgerAddress.SEPARATOR_REGEX;
+
 import org.interledger.core.InterledgerAddress.AllocationScheme;
 
 import org.immutables.value.Value;
@@ -201,10 +205,10 @@ public interface InterledgerAddressPrefix {
         .compile(VALID_ADDRESS_PREFIX_REGEX);
 
     private static final int ADDRESS_MIN_SEGMENTS = 1;
-    private static final String SCHEME_REGEX = "(g|private|example|peer|self|test[1-3]?)";
-    private static final String SEGMENT_REGEX = "[a-zA-Z0-9_~-]+";
-    private static final String SEPARATOR_REGEX = "[.]";
+
     private static final String ADDRESS_LENGTH_BOUNDARIES_REGEX = "(?=^.{1,1021}$)";
+    private static final Pattern ADDRESS_LENGTH_BOUNDARIES_PATTERN = Pattern
+        .compile(ADDRESS_LENGTH_BOUNDARIES_REGEX);
 
     /**
      * Precondition enforcer that ensures the value is a valid Interledger Address.
@@ -238,14 +242,14 @@ public interface InterledgerAddressPrefix {
       );
       // validates scheme prefix format
       final String schemePrefix = schemeAndSegments.get(0);
-      if (!Pattern.compile(SCHEME_REGEX).matcher(schemePrefix).matches()) {
+      if (!SCHEME_PATTERN.matcher(schemePrefix).matches()) {
         return String.format(Error.INVALID_SCHEME_PREFIX.getMessageFormat(), schemePrefix);
       }
 
       // validates each segment format
       final List<String> segments = schemeAndSegments.stream().skip(1).collect(Collectors.toList());
       final int segmentsSize = segments.size();
-      final Matcher segmentMatcher = Pattern.compile(SEGMENT_REGEX).matcher("");
+      final Matcher segmentMatcher = SEGMENT_PATTERN.matcher("");
       final Optional<String> invalidSegment = segments.stream()
           .filter(segment -> {
             segmentMatcher.reset(segment);
@@ -262,8 +266,7 @@ public interface InterledgerAddressPrefix {
       }
 
       // validates max address length
-      if (!Pattern.compile(ADDRESS_LENGTH_BOUNDARIES_REGEX).matcher(invalidAddressString)
-          .matches()) {
+      if (!ADDRESS_LENGTH_BOUNDARIES_PATTERN.matcher(invalidAddressString).matches()) {
         return Error.ADDRESS_OVERFLOW.getMessageFormat();
       }
 

--- a/ilp-core/src/main/java/org/interledger/core/InterledgerPacket.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerPacket.java
@@ -9,9 +9,9 @@ package org.interledger.core;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,4 +21,11 @@ package org.interledger.core;
  */
 
 public interface InterledgerPacket {
+
+  /**
+   * Arbitrary data that can be attached to a packet.
+   *
+   * @return A byte array.
+   */
+  byte[] getData();
 }

--- a/ilp-core/src/main/java/org/interledger/core/InterledgerPreparePacket.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerPreparePacket.java
@@ -9,9 +9,9 @@ package org.interledger.core;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -71,7 +71,10 @@ public interface InterledgerPreparePacket extends InterledgerPacket {
     return new InterledgerPreparePacketBuilder();
   }
 
-  BigInteger getAmount();
+  @Default
+  default BigInteger getAmount() {
+    return BigInteger.ZERO;
+  }
 
   Instant getExpiresAt();
 

--- a/ilp-core/src/main/java/org/interledger/core/InterledgerProtocolException.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerProtocolException.java
@@ -9,9 +9,9 @@ package org.interledger.core;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,20 +35,20 @@ public class InterledgerProtocolException extends InterledgerRuntimeException {
    * Required-args constructor.
    *
    * @param interledgerRejectPacket An instance of {@link InterledgerRejectPacket} that is the
-   *                                 underlying error encapsulated by this exception.
+   *                                underlying error encapsulated by this exception.
    */
   public InterledgerProtocolException(final InterledgerRejectPacket interledgerRejectPacket) {
-    super("Interledger Rejection.");
+    super(String.format("Interledger Rejection: %s", interledgerRejectPacket.getMessage()));
     this.interledgerRejectPacket = fillInterledgerRejectPacket(interledgerRejectPacket);
   }
 
   /**
-   * Constructs a new Interledger protocol exception with the specified reject packet and
-   * detail message.
+   * Constructs a new Interledger protocol exception with the specified reject packet and detail
+   * message.
    *
    * @param interledgerRejectPacket An instance of {@link InterledgerRejectPacket} that is the
-   *                                 underlying error encapsulated by this exception.
-   * @param message The detail message.
+   *                                underlying error encapsulated by this exception.
+   * @param message                 The detail message.
    */
   public InterledgerProtocolException(final InterledgerRejectPacket interledgerRejectPacket,
       final String message) {

--- a/ilp-core/src/main/java/org/interledger/core/InterledgerRejectPacket.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerRejectPacket.java
@@ -9,9 +9,9 @@ package org.interledger.core;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,8 +23,6 @@ package org.interledger.core;
 import org.interledger.annotations.Immutable;
 
 import org.immutables.value.Value.Default;
-
-import java.util.Arrays;
 
 public interface InterledgerRejectPacket extends InterledgerPacket {
 
@@ -57,14 +55,6 @@ public interface InterledgerRejectPacket extends InterledgerPacket {
    * @return An {@link InterledgerAddress}.
    */
   String getMessage();
-
-  /**
-   * Machine-readable data. The format is defined for each error code. Implementations MUST follow
-   *     the correct format for the code given in the `code` field.
-   *
-   * @return The optional error data.
-   */
-  byte[] getData();
 
   @Immutable
   abstract class AbstractInterledgerRejectPacket implements InterledgerRejectPacket {

--- a/ilp-core/src/test/java/org/interledger/core/InterledgerAddressPrefixTest.java
+++ b/ilp-core/src/test/java/org/interledger/core/InterledgerAddressPrefixTest.java
@@ -1,0 +1,559 @@
+package org.interledger.core;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.interledger.core.InterledgerAddressPrefix.AbstractInterledgerAddressPrefix.Error.ADDRESS_OVERFLOW;
+import static org.interledger.core.InterledgerAddressPrefix.AbstractInterledgerAddressPrefix.Error.ILLEGAL_ENDING;
+import static org.interledger.core.InterledgerAddressPrefix.AbstractInterledgerAddressPrefix.Error.INVALID_SCHEME_PREFIX;
+import static org.interledger.core.InterledgerAddressPrefix.AbstractInterledgerAddressPrefix.Error.INVALID_SEGMENT;
+import static org.junit.Assert.fail;
+
+import org.interledger.core.InterledgerAddress.AllocationScheme;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link InterledgerAddressPrefix}.
+ */
+public class InterledgerAddressPrefixTest {
+
+  private static final String TEST1_US_USD = "test1.us.usd";
+  private static final String TEST1_US_USD_BOB = TEST1_US_USD + ".bob";
+
+  private static final String JUST_RIGHT =
+      "g.foo.0123"
+          + "45678901234567890123456789012345678901234567890123456789012345678901234567890123456"
+          + "78901234567890123456789012345678901234567890123456789012345678901234567890123456789"
+          + "01234567890123456789012345678901234567890123456789012345678901234567890123456789012"
+          + "34567890123456789012345678901234567890123456789012345678901234567890123456789012345"
+          + "67890123456789012345678901234567890123456789012345678901234567890123456789012345678"
+          + "90123456789012345678901234567890123456789012345678901234567890123456789012345678901"
+          + "23456789012345678901234567890123456789012345678901234567890123456789012345678901234"
+          + "56789012345678901234567890123456789012345678901234567890123456789012345678901234567"
+          + "89012345678901234567890123456789012345678901234567890123456789012345678901234567890"
+          + "12345678901234567890123456789012345678901234567890123456789012345678901234567890123"
+          + "45678901234567890123456789012345678901234567890123456789012345678901234567890123456"
+          + "78901234567890123456789012345678901234567890123456789012345678901234567890123456789"
+          + "01234567891234567";
+
+  private static final String TOO_LONG = JUST_RIGHT + "0";
+  private static final String G_FOO = "g.foo";
+
+  ////////////////////////
+  // Builder Tests
+  ////////////////////////
+
+  @Test(expected = IllegalStateException.class)
+  public void test_constructor_with_uninitialized_build() {
+    try {
+      InterledgerAddressPrefix.builder().build();
+    } catch (IllegalStateException e) {
+      //Removed message check. This exception is raised by the Immutable generated code.
+      assertThat(e.getMessage(),
+          is("Cannot build InterledgerAddressPrefix, some of required attributes are not set [value]"));
+      throw e;
+    }
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void test_wither_with_null_value() {
+    try {
+      InterledgerAddressPrefix.builder()
+          .value(null)
+          .build();
+    } catch (NullPointerException e) {
+      assertThat(e.getMessage(), is("value"));
+      throw e;
+    }
+  }
+
+  @Test
+  public void testConstruction_DeliverableAddress() {
+    final InterledgerAddressPrefix address = InterledgerAddressPrefix.builder()
+        .value(TEST1_US_USD_BOB).build();
+    assertThat(address.getValue(), is(TEST1_US_USD_BOB));
+  }
+
+  @Test
+  public void testConstruction_LedgerPrefix() {
+    final InterledgerAddressPrefix address = InterledgerAddressPrefix.builder().value(TEST1_US_USD)
+        .build();
+    assertThat(address.getValue(), is(TEST1_US_USD));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void test_empty_address() {
+    try {
+      InterledgerAddressPrefix.builder().value("").build();
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is(String.format(INVALID_SCHEME_PREFIX.getMessageFormat(), "")));
+      throw e;
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void test_blank_address() {
+    try {
+      InterledgerAddressPrefix.builder().value("  ").build();
+    } catch (IllegalArgumentException e) {
+      assertThat(
+          e.getMessage(),
+          is(String.format(
+              INVALID_SCHEME_PREFIX
+                  .getMessageFormat(),
+              "  "))
+      );
+      throw e;
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void test_address_with_space() {
+    try {
+      InterledgerAddressPrefix.builder().value(TEST1_US_USD_BOB + " space").build();
+    } catch (IllegalArgumentException e) {
+      assertThat(
+          e.getMessage(),
+          is(String.format(INVALID_SEGMENT.getMessageFormat(), "bob space"))
+      );
+      throw e;
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void test_address_too_long() {
+    try {
+      InterledgerAddressPrefix.builder().value(TOO_LONG).build();
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is(ADDRESS_OVERFLOW.getMessageFormat()));
+      throw e;
+    }
+  }
+
+  @Test
+  public void test_address_just_right_length() {
+    // This is 1023 characters long...
+    final InterledgerAddressPrefix address = InterledgerAddressPrefix.builder().value(JUST_RIGHT)
+        .build();
+    assertThat(address.getValue(), is(JUST_RIGHT));
+  }
+
+  @Test
+  public void test_address_all_valid_characters() {
+    final String allValues = "g.0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_~.-";
+    final InterledgerAddressPrefix address = InterledgerAddressPrefix.builder().value(allValues)
+        .build();
+    assertThat(address.getValue(), is(allValues));
+  }
+
+  ////////////////////////
+  // Accessors
+  ////////////////////////
+
+  @Test
+  public void testValue() {
+    assertThat(InterledgerAddressPrefix.of("g.foo.bob").getValue(), is("g.foo.bob"));
+  }
+
+  @Test
+  public void testStartsWithString() {
+    final InterledgerAddressPrefix address = InterledgerAddressPrefix.of("g.foo.bob");
+    assertThat(address.startsWith("g"), is(true));
+    assertThat(address.startsWith("g"), is(true));
+    assertThat(address.startsWith(G_FOO), is(true));
+    assertThat(address.startsWith(G_FOO), is(true));
+    assertThat(address.startsWith("g.foo.bob"), is(true));
+    assertThat(address.startsWith("test.foo.bob"), is(false));
+  }
+
+  @Test
+  public void testStartsWithInterledgerAddressPrefix() {
+    final InterledgerAddressPrefix address = InterledgerAddressPrefix.of("g.foo.bob");
+    assertThat(address.startsWith(InterledgerAddressPrefix.of(G_FOO)), is(true));
+    assertThat(address.startsWith(InterledgerAddressPrefix.of("g.foo.bob")), is(true));
+    assertThat(address.startsWith(InterledgerAddressPrefix.of("g.foo.bob.bar")), is(false));
+    assertThat(address.startsWith(InterledgerAddressPrefix.of("g.foo.bobbar")), is(false));
+    assertThat(address.startsWith(InterledgerAddressPrefix.of("test1.foo.bob")), is(false));
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testAddressWithNull() {
+    final InterledgerAddressPrefix addressPrefix = InterledgerAddressPrefix.of(G_FOO);
+    try {
+      addressPrefix.with(null);
+    } catch (NullPointerException e) {
+      assertThat(e.getMessage(), is("addressSegment must not be null!"));
+      throw e;
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testAddressWithEmpty() {
+    final InterledgerAddressPrefix addressPrefix = InterledgerAddressPrefix.of(G_FOO);
+    try {
+      addressPrefix.with("");
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is(ILLEGAL_ENDING.getMessageFormat()));
+      throw e;
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testAddressWithBlank() {
+    final InterledgerAddressPrefix addressPrefix = InterledgerAddressPrefix.of(G_FOO);
+    try {
+      addressPrefix.with("  ");
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is(String.format(INVALID_SEGMENT.getMessageFormat(), "  ")));
+      throw e;
+    }
+  }
+
+  /**
+   * Validates adding an address prefix (as an InterledgerAddressPrefix) to an address prefix.
+   */
+  @Test
+  public void testAddressPrefixWithAddressPrefix() {
+    final InterledgerAddressPrefix destinationAddress = InterledgerAddressPrefix.of("g.foo.bob");
+    final String additionalDestinationAddress = "boz";
+    assertThat(destinationAddress.with(additionalDestinationAddress).getValue(),
+        is("g.foo.bob.boz"));
+  }
+
+  /**
+   * Validates adding a destination address (as an InterledgerAddressPrefix) to an address prefix.
+   */
+  @Test
+  public void testAddressPrefixWithDestinationAddress() {
+    final InterledgerAddressPrefix addressPrefix = InterledgerAddressPrefix.of(G_FOO);
+    final String additionalDestinationAddress = "bob";
+    assertThat(addressPrefix.with(additionalDestinationAddress).getValue(), is("g.foo.bob"));
+  }
+
+  /**
+   * Validates adding a destination address (as an InterledgerAddressPrefix) to a destination
+   * address.
+   */
+  @Test
+  public void testDestinationAddressWithDestinationAddress() {
+    final InterledgerAddressPrefix destinationAddress = InterledgerAddressPrefix.of("g.foo.bob");
+    final String additionalDestinationAddress = "boz";
+    assertThat(destinationAddress.with(additionalDestinationAddress).getValue(),
+        is("g.foo.bob.boz"));
+  }
+
+  /**
+   * Validates adding an address prefix  (as an InterledgerAddressPrefix) to a destination address.
+   */
+  @Test
+  public void testAddressWithAddress() {
+    final InterledgerAddressPrefix destinationAddress = InterledgerAddressPrefix.of("g.foo.bob");
+    final String additionalDestinationAddress = "boz";
+    assertThat(destinationAddress.with(additionalDestinationAddress).getValue(),
+        is("g.foo.bob.boz"));
+  }
+
+  @Test
+  public void testAllocationScheme() {
+    final InterledgerAddressPrefix prefix = InterledgerAddressPrefix.of("g");
+    assertThat(prefix.getValue(), is("g"));
+  }
+
+  @Test
+  public void testGetPrefixFromAllocationSchemePrefix() {
+    assertThat(InterledgerAddressPrefix.of("g").getPrefix().isPresent(), is(false));
+  }
+
+  @Test
+  public void testGetPrefixFromShortPrefix() {
+    assertThat(InterledgerAddressPrefix.of("g.1").getPrefix().isPresent(), is(true));
+  }
+
+  @Test
+  public void testGetPrefixFromPrefix() {
+    final InterledgerAddressPrefix address = InterledgerAddressPrefix.of("g.example");
+    assertThat(address.getPrefix().isPresent(), is(true));
+  }
+
+  @Test
+  public void testGetPrefixFromLongPrefix() {
+    final InterledgerAddressPrefix address = InterledgerAddressPrefix
+        .of("g.alpha.beta.charlie.delta.echo");
+    assertThat(address.getPrefix().get().getValue(), is("g.alpha.beta.charlie.delta"));
+  }
+
+  @Test
+  public void testGetPrefixFromAddress() {
+    final InterledgerAddressPrefix address = InterledgerAddressPrefix.of("g.example.bob");
+    assertThat(address.getPrefix().get().getValue(), is("g.example"));
+  }
+
+  @Test
+  public void testGetPrefixFromShortAddress() {
+    assertThat(InterledgerAddressPrefix.of("g.bob.foo").getPrefix().get().getValue(), is("g.bob"));
+    assertThat(InterledgerAddressPrefix.of("g.b.f").getPrefix().get().getValue(), is("g.b"));
+  }
+
+  @Test
+  public void testGetPrefixFromLongAddress() {
+    final InterledgerAddressPrefix address = InterledgerAddressPrefix
+        .of("g.alpha.beta.charlie.delta.echo");
+    assertThat(address.getPrefix().get().getValue(), is("g.alpha.beta.charlie.delta"));
+  }
+
+  @Test
+  public void testHasPrefix() {
+    assertThat(InterledgerAddressPrefix.of("g.bob").hasPrefix(), is(true));
+    assertThat(InterledgerAddressPrefix.of("g.bob.foo").hasPrefix(), is(true));
+    assertThat(InterledgerAddressPrefix.of("g.bob.foo").hasPrefix(), is(true));
+    assertThat(InterledgerAddressPrefix.of("self.bob").hasPrefix(), is(true));
+
+    assertThat(InterledgerAddressPrefix.of("g.1.1").hasPrefix(), is(true));
+    assertThat(InterledgerAddressPrefix.of("private.1.1").hasPrefix(), is(true));
+    assertThat(InterledgerAddressPrefix.of("example.1.1").hasPrefix(), is(true));
+    assertThat(InterledgerAddressPrefix.of("peer.1.1").hasPrefix(), is(true));
+    assertThat(InterledgerAddressPrefix.of("self.1.1").hasPrefix(), is(true));
+    assertThat(InterledgerAddressPrefix.of("test.1.1").hasPrefix(), is(true));
+    assertThat(InterledgerAddressPrefix.of("test1.1.1").hasPrefix(), is(true));
+    assertThat(InterledgerAddressPrefix.of("test2.1.1").hasPrefix(), is(true));
+    assertThat(InterledgerAddressPrefix.of("test3.1.1").hasPrefix(), is(true));
+  }
+
+  @Test
+  public void testAddressEqualsHashcode() {
+    final InterledgerAddressPrefix addressPrefix1 = InterledgerAddressPrefix.of("g.foo.bob");
+    final InterledgerAddressPrefix addressPrefix2 = InterledgerAddressPrefix.of("g.foo.bob");
+    final InterledgerAddressPrefix addressPrefix3 = InterledgerAddressPrefix.of("g.foo.bar");
+
+    assertThat(addressPrefix1.hashCode() == addressPrefix2.hashCode(), is(true));
+    assertThat(addressPrefix1 == addressPrefix2, is(true));
+    assertThat(addressPrefix1.equals(addressPrefix2), is(true));
+    assertThat(addressPrefix2.equals(addressPrefix1), is(true));
+    assertThat(addressPrefix1.toString().equals(addressPrefix2.toString()), is(true));
+
+    assertThat(addressPrefix1.hashCode() == addressPrefix3.hashCode(), is(false));
+    assertThat(addressPrefix1 == addressPrefix3, is(false));
+    assertThat(addressPrefix1.equals(addressPrefix3), is(false));
+    assertThat(addressPrefix3.equals(addressPrefix1), is(false));
+    assertThat(addressPrefix1.toString().equals(addressPrefix3.toString()), is(false));
+  }
+
+  @Test
+  public void testToString() {
+    assertThat(InterledgerAddressPrefix.of("g.foo.bob").toString(),
+        is("InterledgerAddressPrefix{value=g.foo.bob}"));
+    assertThat(InterledgerAddressPrefix.of(G_FOO).toString(),
+        is("InterledgerAddressPrefix{value=g.foo}"));
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testValidateWithNullAddress() {
+    InterledgerAddressPrefix.builder().value(null).build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateWithInvalidSchemePrefix_02() {
+    assertValidationErrorThenThrow(".self",
+        INVALID_SCHEME_PREFIX);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateWithInvalidSchemePrefix_04() {
+    assertValidationErrorThenThrow(".foo",
+        INVALID_SCHEME_PREFIX);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateWithInvalidSchemePrefix_05() {
+    assertValidationErrorThenThrow("gg",
+        INVALID_SCHEME_PREFIX,
+        "gg");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateWithInvalidSchemePrefix_06() {
+    assertValidationErrorThenThrow(" g",
+        INVALID_SCHEME_PREFIX,
+        " g");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateWithInvalidSchemePrefix_07() {
+    assertValidationErrorThenThrow("g ",
+        INVALID_SCHEME_PREFIX,
+        "g ");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateWithInvalidSchemePrefix_08() {
+    assertValidationErrorThenThrow("@@@",
+        INVALID_SCHEME_PREFIX,
+        "@@@");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateWithInvalidSegment_01() {
+    assertValidationErrorThenThrow("g.@@@",
+        INVALID_SEGMENT, "@@@");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateWithInvalidSegment_02() {
+    assertValidationErrorThenThrow("g. ",
+        INVALID_SEGMENT, " ");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateWithInvalidSegment_03() {
+    assertValidationErrorThenThrow("g.é",
+        INVALID_SEGMENT, "é");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateWithInvalidSegment_04() {
+    assertValidationErrorThenThrow("g.", ILLEGAL_ENDING,
+        "");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateWithInvalidSegment_04b() {
+    assertValidationErrorThenThrow("g.foo.",
+        ILLEGAL_ENDING, "");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateWithInvalidSegment_05() {
+    assertValidationErrorThenThrow("g..bar",
+        INVALID_SEGMENT, "");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateWithInvalidSegment_06() {
+    assertValidationErrorThenThrow("g.foo.@.baz",
+        INVALID_SEGMENT, "@");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateWithInvalidSegment_07() {
+    assertValidationErrorThenThrow("g.foo.bar.a@1",
+        INVALID_SEGMENT, "a@1");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateWithInvalidSegment_08() {
+    assertValidationErrorThenThrow("g.foo.bar.baz ",
+        INVALID_SEGMENT, "baz ");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateWithInvalidSegment_09() {
+    assertValidationErrorThenThrow("g.foo.bar.baz\r\n",
+        INVALID_SEGMENT, "baz\r\n");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateWithSegmentsUnderflow() {
+    assertValidationErrorThenThrow("",
+        INVALID_SCHEME_PREFIX);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateWithLengthOverflow() {
+    assertValidationErrorThenThrow(TOO_LONG,
+        ADDRESS_OVERFLOW);
+  }
+
+  private void assertValidationErrorThenThrow(final String actualAddressString,
+      final InterledgerAddressPrefix.AbstractInterledgerAddressPrefix.Error expectedError,
+      final Object... errorParams) {
+    try {
+      InterledgerAddressPrefix.builder().value(actualAddressString).build();
+      fail("Should have thrown an IllegalArgumentException");
+    } catch (final IllegalArgumentException e) {
+      assertThat(e.getMessage(), is(String.format(expectedError.getMessageFormat(), errorParams)));
+      throw e;
+    } catch (final Exception e) {
+      fail("Should have thrown an IllegalArgumentException");
+      throw e;
+    }
+  }
+
+  ////////////////////
+  // test getRootPrefix
+  ////////////////////
+
+  @Test
+  public void getRootPrefix() {
+    assertThat(InterledgerAddressPrefix.of("g.baz").getRootPrefix().getValue(), is("g"));
+    assertThat(InterledgerAddressPrefix.of("g.baz.bool").getRootPrefix().getValue(), is("g"));
+    assertThat(InterledgerAddressPrefix.of("g.baz.bool.foo").getRootPrefix().getValue(), is("g"));
+    assertThat(InterledgerAddressPrefix.of("g.baz.bool.foo.bar.boo").getRootPrefix().getValue(),
+        is("g"));
+    assertThat(InterledgerAddressPrefix.of("g").getRootPrefix().getValue(), is("g"));
+  }
+
+  ////////////////////
+  // test from InterledgerAddress
+  ////////////////////
+
+  @Test(expected = NullPointerException.class)
+  public void testFromAddressWithNull() {
+    try {
+      InterledgerAddressPrefix.from((InterledgerAddress) null);
+    } catch (NullPointerException e) {
+      assertThat(e.getMessage(), is(nullValue()));
+      throw e;
+    }
+  }
+
+  @Test
+  public void testFromAddressWithAddress() {
+    final InterledgerAddressPrefix prefix = InterledgerAddressPrefix
+        .from(InterledgerAddress.of(G_FOO));
+    assertThat(prefix.getValue(), is(G_FOO));
+  }
+
+  ////////////////////
+  // test from AllocationScheme
+  ////////////////////
+
+  @Test(expected = NullPointerException.class)
+  public void testFromAllocationSchemeWithNull() {
+    try {
+      InterledgerAddressPrefix.from((AllocationScheme) null);
+    } catch (NullPointerException e) {
+      assertThat(e.getMessage(), is(nullValue()));
+      throw e;
+    }
+  }
+
+  @Test
+  public void testFromAddressWithAllocationScheme() {
+    final InterledgerAddressPrefix allocationScheme = InterledgerAddressPrefix
+        .from(AllocationScheme.GLOBAL);
+    assertThat(allocationScheme, is(InterledgerAddressPrefix.GLOBAL));
+  }
+
+  @Test
+  public void testPrefixesWithAllocationScheme() {
+    assertThat(InterledgerAddressPrefix.from(AllocationScheme.GLOBAL),
+        is(InterledgerAddressPrefix.GLOBAL));
+    assertThat(InterledgerAddressPrefix.from(AllocationScheme.EXAMPLE),
+        is(InterledgerAddressPrefix.EXAMPLE));
+    assertThat(InterledgerAddressPrefix.from(AllocationScheme.PRIVATE),
+        is(InterledgerAddressPrefix.PRIVATE));
+    assertThat(InterledgerAddressPrefix.from(AllocationScheme.PEER),
+        is(InterledgerAddressPrefix.PEER));
+    assertThat(InterledgerAddressPrefix.from(AllocationScheme.SELF),
+        is(InterledgerAddressPrefix.SELF));
+    assertThat(InterledgerAddressPrefix.from(AllocationScheme.TEST),
+        is(InterledgerAddressPrefix.TEST));
+    assertThat(InterledgerAddressPrefix.from(AllocationScheme.TEST1),
+        is(InterledgerAddressPrefix.TEST1));
+    assertThat(InterledgerAddressPrefix.from(AllocationScheme.TEST2),
+        is(InterledgerAddressPrefix.TEST2));
+    assertThat(InterledgerAddressPrefix.from(AllocationScheme.TEST3),
+        is(InterledgerAddressPrefix.TEST3));
+  }
+}

--- a/ilp-core/src/test/java/org/interledger/core/InterledgerAddressSchemeTest.java
+++ b/ilp-core/src/test/java/org/interledger/core/InterledgerAddressSchemeTest.java
@@ -67,7 +67,7 @@ public class InterledgerAddressSchemeTest {
         .builder()
         .value(this.allocationScheme)
         .build();
-    assertThat(allocationScheme.value(), is(this.allocationScheme));
+    assertThat(allocationScheme.getValue(), is(this.allocationScheme));
   }
 
   /**

--- a/ilp-core/src/test/java/org/interledger/core/InterledgerAddressTest.java
+++ b/ilp-core/src/test/java/org/interledger/core/InterledgerAddressTest.java
@@ -68,8 +68,8 @@ public class InterledgerAddressTest {
     try {
       InterledgerAddress.builder().build();
     } catch (IllegalStateException e) {
-      //Removed message check. This exception is raised by the Immutable generated code.
-      //assertThat(e.getMessage(), is("value must not be null!"));
+      assertThat(e.getMessage(),
+          is("Cannot build InterledgerAddress, some of required attributes are not set [value]"));
       throw e;
     }
   }

--- a/ilp-core/src/test/java/org/interledger/core/InterledgerPreparePacketTest.java
+++ b/ilp-core/src/test/java/org/interledger/core/InterledgerPreparePacketTest.java
@@ -115,17 +115,14 @@ public class InterledgerPreparePacketTest {
     }
 
     //No amount
-    try {
-      InterledgerPreparePacket.builder()
-          .destination(mock(InterledgerAddress.class))
-          .executionCondition(mock(InterledgerCondition.class))
-          .expiresAt(Instant.now())
-          .build();
-      fail();
-    } catch (IllegalStateException e) {
-      assert (e.getMessage().startsWith("Cannot build InterledgerPreparePacket, "
-          + "some of required attributes are not set"));
-    }
+    final InterledgerPreparePacket preparePacket = InterledgerPreparePacket
+        .builder()
+        .destination(mock(InterledgerAddress.class))
+        .executionCondition(mock(InterledgerCondition.class))
+        .expiresAt(Instant.now())
+        .build();
+    assertThat(preparePacket, is(not(nullValue())));
+    assertThat(preparePacket.getAmount(), is(BigInteger.ZERO));
 
     //No destination
     try {


### PR DESCRIPTION
* Revert InterledgerAddress.value to `getValue`.
* Add `InterledgerAddressPrefix` that can be an address or allocation scheme, plus unit test.
* Add Codec for `InterledgerAddressPrefix`, plus unit tests.
* Move `data` to `InterlederPacket` parent interface.
* Set default value of Prepare packet to ZERO.
* Add Javadoc to InterledgerFulfillPacket.
* Make BtpSubProtocolContentTypeTest use the proper type (Short).

Signed-off-by: sappenin <sappenin@gmail.com>