### PR TITLE
Fixes #199 Adds startsWith(prefix) and tests to the InterledgerAddress interface

### DIFF
--- a/ilp-core/src/main/java/org/interledger/core/InterledgerAddress.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerAddress.java
@@ -141,6 +141,18 @@ public interface InterledgerAddress {
   }
 
   /**
+   * <p>Tests if this InterledgerAddress starts with the specified {@code addressPrefix}.</p>
+   *
+   * @param addressPrefix An {@link InterledgerAddressPrefix} to compare against.
+   *
+   * @return {@code true} if this InterledgerAddress begins with the specified prefix else {@code false}.
+   */
+  default boolean startsWith(final InterledgerAddressPrefix addressPrefix) {
+    Objects.requireNonNull(addressPrefix, "addressPrefix must not be null!");
+    return this.startsWith(addressPrefix.getValue());
+  }
+
+  /**
    * <p>Return a new {@link InterledgerAddress} by suffixing the supplied {@code addressSegment}
    * onto the current address.</p>
    *

--- a/ilp-core/src/test/java/org/interledger/core/InterledgerAddressTest.java
+++ b/ilp-core/src/test/java/org/interledger/core/InterledgerAddressTest.java
@@ -196,6 +196,47 @@ public class InterledgerAddressTest {
     assertThat(address.startsWith(InterledgerAddress.of("test1.foo.bob")), is(false));
   }
 
+  @Test
+  public void testStartsWithInterledgerAddressPrefix() {
+    final InterledgerAddress address = InterledgerAddress.of("g.foo.bob");
+    assertThat(address.startsWith(InterledgerAddressPrefix.of("g")), is(true));
+    assertThat(address.startsWith(InterledgerAddressPrefix.of("g.foo")), is(true));
+    assertThat(address.startsWith(InterledgerAddressPrefix.of("g.foo.bob")), is(true));
+    assertThat(address.startsWith(InterledgerAddressPrefix.of("g.foo.bar")), is(false));
+    assertThat(address.startsWith(InterledgerAddressPrefix.of("test.foo")), is(false));
+
+    final InterledgerAddress smallAddress = InterledgerAddress.of("g.foo");
+    assertThat(smallAddress.startsWith(InterledgerAddressPrefix.of("g")), is(true));
+    assertThat(smallAddress.startsWith(InterledgerAddressPrefix.of("g.foo")), is(true));
+    assertThat(smallAddress.startsWith(InterledgerAddressPrefix.of("g.foo.bob")), is(false));
+    assertThat(smallAddress.startsWith(InterledgerAddressPrefix.of("g.foo.bar")), is(false));
+    assertThat(smallAddress.startsWith(InterledgerAddressPrefix.of("test.foo")), is(false));
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testAddressPrefixStartsWithNull() {
+    final InterledgerAddress address = InterledgerAddress.of("g.foo");
+    InterledgerAddressPrefix addressPrefix = null;
+    try {
+      address.startsWith(addressPrefix); // addressPrefix will be null
+    } catch (NullPointerException e) {
+      assertThat(e.getMessage(), is("addressPrefix must not be null!"));
+      throw e;
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testAddressPrefixStartsWithEmpty() {
+    final InterledgerAddress address = InterledgerAddress.of("g.foo.bob");
+    InterledgerAddressPrefix addressPrefix = InterledgerAddressPrefix.of("");
+    try {
+      address.startsWith(addressPrefix);
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is("addressPrefix must not be empty!"));
+      throw e;
+    }
+  }
+
   @Test(expected = NullPointerException.class)
   public void testAddressWithNull() {
     final InterledgerAddress addressPrefix = InterledgerAddress.of("g.foo");


### PR DESCRIPTION
- Add `startsWith()` to accept `InterledgerAddressPrefix`
- Add corresponding tests for `InterledgerAddress` that `startsWith(prefix)`

Signed-off-by: sudheesh001 <sudheesh1995@outlook.com>