### PR TITLE
Fixes #212 Remove Optionality from InterledgerAddress getPrefix

### DIFF
--- a/ilp-core/src/main/java/org/interledger/core/InterledgerAddress.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerAddress.java
@@ -181,24 +181,12 @@ public interface InterledgerAddress {
    *
    * @return An optionally present parent-prefix as an {@link InterledgerAddressPrefix}.
    */
-  default Optional<InterledgerAddressPrefix> getPrefix() {
+  default InterledgerAddressPrefix getPrefix() {
     // An address will always contain at least one period (.), so we can always return its prefix.
     final String value = getValue();
-    return Optional.of(
-        InterledgerAddressPrefix.builder()
+    return InterledgerAddressPrefix.builder()
             .value(value.substring(0, value.lastIndexOf(".")))
-            .build()
-    );
-  }
-
-  /**
-   * <p>Determines if this ILP Address has a parent-prefix.</p>
-   *
-   * @return {@code true} if this address has more than two segments after the allocation scheme. Otherwise return
-   *     {@code false}.
-   */
-  default boolean hasPrefix() {
-    return getPrefix().isPresent();
+            .build();
   }
 
   /**

--- a/ilp-core/src/test/java/org/interledger/core/InterledgerAddressTest.java
+++ b/ilp-core/src/test/java/org/interledger/core/InterledgerAddressTest.java
@@ -392,57 +392,39 @@ public class InterledgerAddressTest {
 
   @Test
   public void testGetPrefixFromShortPrefix() {
-    assertThat(InterledgerAddress.of("g.1").getPrefix().isPresent(), is(true));
-    assertThat(InterledgerAddress.of("g.1").getPrefix().get(), is(InterledgerAddressPrefix.of("g")));
+    assertThat(!InterledgerAddress.of("g.1").getPrefix().getValue().isEmpty(), is(true));
+    assertThat(InterledgerAddress.of("g.1").getPrefix(), is(InterledgerAddressPrefix.of("g")));
   }
 
   @Test
   public void testGetPrefixFromPrefix() {
     final InterledgerAddress address = InterledgerAddress.of("g.example");
-    assertThat(address.getPrefix().isPresent(), is(true));
-    assertThat(address.getPrefix().get(), is(InterledgerAddressPrefix.of("g")));
+    assertThat(!address.getPrefix().getValue().isEmpty(), is(true));
+    assertThat(address.getPrefix(), is(InterledgerAddressPrefix.of("g")));
   }
 
   @Test
   public void testGetPrefixFromLongPrefix() {
     final InterledgerAddress address = InterledgerAddress.of("g.alpha.beta.charlie.delta.echo");
-    assertThat(address.getPrefix().get().getValue(), is("g.alpha.beta.charlie.delta"));
+    assertThat(address.getPrefix().getValue(), is("g.alpha.beta.charlie.delta"));
   }
 
   @Test
   public void testGetPrefixFromAddress() {
     final InterledgerAddress address = InterledgerAddress.of("g.example.bob");
-    assertThat(address.getPrefix().get().getValue(), is("g.example"));
+    assertThat(address.getPrefix().getValue(), is("g.example"));
   }
 
   @Test
   public void testGetPrefixFromShortAddress() {
-    assertThat(InterledgerAddress.of("g.bob.foo").getPrefix().get().getValue(), is("g.bob"));
-    assertThat(InterledgerAddress.of("g.b.f").getPrefix().get().getValue(), is("g.b"));
+    assertThat(InterledgerAddress.of("g.bob.foo").getPrefix().getValue(), is("g.bob"));
+    assertThat(InterledgerAddress.of("g.b.f").getPrefix().getValue(), is("g.b"));
   }
 
   @Test
   public void testGetPrefixFromLongAddress() {
     final InterledgerAddress address = InterledgerAddress.of("g.alpha.beta.charlie.delta.echo");
-    assertThat(address.getPrefix().get().getValue(), is("g.alpha.beta.charlie.delta"));
-  }
-
-  @Test
-  public void testHasPrefix() {
-    assertThat(InterledgerAddress.of("g.bob").hasPrefix(), is(true));
-    assertThat(InterledgerAddress.of("g.bob.foo").hasPrefix(), is(true));
-    assertThat(InterledgerAddress.of("g.bob.foo").hasPrefix(), is(true));
-    assertThat(InterledgerAddress.of("self.bob").hasPrefix(), is(true));
-
-    assertThat(InterledgerAddress.of("g.1.1").hasPrefix(), is(true));
-    assertThat(InterledgerAddress.of("private.1.1").hasPrefix(), is(true));
-    assertThat(InterledgerAddress.of("example.1.1").hasPrefix(), is(true));
-    assertThat(InterledgerAddress.of("peer.1.1").hasPrefix(), is(true));
-    assertThat(InterledgerAddress.of("self.1.1").hasPrefix(), is(true));
-    assertThat(InterledgerAddress.of("test.1.1").hasPrefix(), is(true));
-    assertThat(InterledgerAddress.of("test1.1.1").hasPrefix(), is(true));
-    assertThat(InterledgerAddress.of("test2.1.1").hasPrefix(), is(true));
-    assertThat(InterledgerAddress.of("test3.1.1").hasPrefix(), is(true));
+    assertThat(address.getPrefix().getValue(), is("g.alpha.beta.charlie.delta"));
   }
 
   @Test


### PR DESCRIPTION
- The `SEGMENTS_UNDERFLOW` logic ensures that `InterledgerAddress` always contains a prefix.
- Removes optionality from the `getPrefix()` method and updates `hasPrefix()` accordingly.
- Updates corresponding tests and implements explicit checking of `hasPrefix()` and `getValue()` checks.
- Removes `hasPrefix()` since the`InterledgerAddress` always has a prefix.

Signed-off-by: sudheesh001 <sudheesh1995@outlook.com>