### PR TITLE
Fixes #196 Implements getInteractions on a given InterledgerAddress

### DIFF
--- a/ilp-core/src/main/java/org/interledger/core/InterledgerAddress.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerAddress.java
@@ -23,6 +23,7 @@ package org.interledger.core;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Lazy;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -150,6 +151,26 @@ public interface InterledgerAddress {
   default boolean startsWith(final InterledgerAddressPrefix addressPrefix) {
     Objects.requireNonNull(addressPrefix, "addressPrefix must not be null!");
     return this.startsWith(addressPrefix.getValue());
+  }
+
+  /**
+   * Return the Interactions as a list of segments for a given {@link InterledgerAddress}.
+   *
+   * @return List of segments returned as {@code List<String>}.
+   */
+  default List<String> getInteractions() {
+    List<String> interactions = new ArrayList<>();
+    String addressValue = this.getValue();
+
+    if (addressValue.contains("~")) {
+      // @sappenin: Can there be multiple interactions listed as g.a.b~ipr.x.y~ipr1.z.w ?
+      List<String> segments = Arrays.stream(addressValue.split("~")).skip(1).collect(Collectors.toList());
+      for (String segment : segments) {
+        List<String> details = Arrays.asList(segment.split(AbstractInterledgerAddress.SEPARATOR_REGEX));
+        interactions.addAll(details);
+      }
+    }
+    return interactions;
   }
 
   /**

--- a/ilp-core/src/test/java/org/interledger/core/InterledgerAddressTest.java
+++ b/ilp-core/src/test/java/org/interledger/core/InterledgerAddressTest.java
@@ -33,6 +33,8 @@ import org.interledger.core.InterledgerAddress.AllocationScheme;
 
 import org.junit.Test;
 
+import java.util.List;
+
 /**
  * JUnit tests to test {@link InterledgerAddress}.
  */
@@ -398,6 +400,28 @@ public class InterledgerAddressTest {
   public void testToString() {
     assertThat(InterledgerAddress.of("g.foo.bob").toString(), is("InterledgerAddress{value=g.foo.bob}"));
     assertThat(InterledgerAddress.of("g.foo").toString(), is("InterledgerAddress{value=g.foo}"));
+  }
+
+  @Test
+  public void testGetInteractions() {
+    InterledgerAddress destinationAddress = InterledgerAddress.of("g.us-fed.ach.0.acmebank.swx0a0.acmecorp.sales.199.~ipr.cdfa5e16-e759-4ba3-88f6-8b9dc83c1868.2");
+    // @sappenin: Is the final match for "~ipr" or "ipr" as the first interaction?
+    String[] interactionsToMatch = {"ipr", "cdfa5e16-e759-4ba3-88f6-8b9dc83c1868", "2"};
+
+    List<String> interactions = destinationAddress.getInteractions();
+
+    assertThat(interactions.size(), is(interactionsToMatch.length));
+    for (int i=0; i < interactions.size(); i++) {
+      assertThat(interactions.get(i), is(interactionsToMatch[i]));
+    }
+  }
+
+  @Test
+  public void testGetInteractionsWhenThereAreNoInteractions() {
+    InterledgerAddress address = InterledgerAddress.of("g.bob.baz");
+    List<String> interactions = address.getInteractions();
+
+    assertThat(interactions.isEmpty(), is(true));
   }
 
   @Test(expected = NullPointerException.class)


### PR DESCRIPTION
- Create a `getInteractions` method for use with `InterledgerAddress`.
- Implement the corresponding test cases for the interactions.

Signed-off-by: sudheesh001 <sudheesh1995@outlook.com>