### PR TITLE
Fixes #214 Adds Overt test cases for of() and removes SEGMENTS_UNDERFLOW in Prefix

### DIFF
--- a/ilp-core/src/main/java/org/interledger/core/InterledgerAddressPrefix.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerAddressPrefix.java
@@ -280,11 +280,6 @@ public interface InterledgerAddressPrefix {
         return String.format(Error.INVALID_SEGMENT.getMessageFormat(), invalidSegment.get());
       }
 
-      // validates the minimum number of segments for a destination address
-      if (segmentsSize < ADDRESS_MIN_SEGMENTS) {
-        return Error.SEGMENTS_UNDERFLOW.getMessageFormat();
-      }
-
       // validates max address length
       if (!ADDRESS_LENGTH_BOUNDARIES_PATTERN.matcher(invalidAddressString).matches()) {
         return Error.ADDRESS_OVERFLOW.getMessageFormat();
@@ -292,7 +287,7 @@ public interface InterledgerAddressPrefix {
 
       // fault: should have found an error cause
       throw new IllegalArgumentException(String.format(
-          "Unable to find error for invalid InterledgerAddress: %s", invalidAddressString
+          "Unable to find error for invalid InterledgerAddress: %s. Please report this as a bug!", invalidAddressString
       ));
     }
 

--- a/ilp-core/src/test/java/org/interledger/core/InterledgerAddressPrefixTest.java
+++ b/ilp-core/src/test/java/org/interledger/core/InterledgerAddressPrefixTest.java
@@ -176,6 +176,39 @@ public class InterledgerAddressPrefixTest {
     assertThat(InterledgerAddressPrefix.of("g.foo.bob").getValue(), is("g.foo.bob"));
   }
 
+  @Test(expected = NullPointerException.class)
+  public void testOfWithNull() {
+    try {
+      InterledgerAddressPrefix.of(null);
+      fail("should have thrown an exception but did not!");
+    } catch (NullPointerException e) {
+      assertThat(e.getMessage(), is("value must not be null!"));
+      throw e;
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testOfWithEmptyString() {
+    try {
+      InterledgerAddressPrefix.of("");
+      fail("should have thrown an exception but did not!");
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is("The '' AllocationScheme is invalid!"));
+      throw e;
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testOfWithBlankString() {
+    try {
+      InterledgerAddressPrefix.of(" ");
+      fail("should have thrown an exception but did not!");
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is("The ' ' AllocationScheme is invalid!"));
+      throw e;
+    }
+  }
+
   @Test
   public void testStartsWithString() {
     final InterledgerAddressPrefix address = InterledgerAddressPrefix.of("g.foo.bob");

--- a/ilp-core/src/test/java/org/interledger/core/InterledgerAddressTest.java
+++ b/ilp-core/src/test/java/org/interledger/core/InterledgerAddressTest.java
@@ -175,6 +175,39 @@ public class InterledgerAddressTest {
     );
   }
 
+  @Test(expected = NullPointerException.class)
+  public void testOfWithNull() {
+    try {
+      InterledgerAddress.of(null);
+      fail("should have thrown an exception but did not!");
+    } catch (NullPointerException e) {
+      assertThat(e.getMessage(), is("value must not be null!"));
+      throw e;
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testOfWithEmptyString() {
+    try {
+      InterledgerAddress.of("");
+      fail("should have thrown an exception but did not!");
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is("InterledgerAddress does not start with a scheme prefix"));
+      throw e;
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testOfWithBlankString() {
+    try {
+      InterledgerAddress.of(" ");
+      fail("should have thrown an exception but did not!");
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), is("The ' ' AllocationScheme is invalid!"));
+      throw e;
+    }
+  }
+
   @Test
   public void testStartsWithString() {
     final InterledgerAddress address = InterledgerAddress.of("g.foo.bob");
@@ -314,6 +347,7 @@ public class InterledgerAddressTest {
   public void testDestinationAddressWithoutEnoughSegments() {
     try {
       InterledgerAddress.of("g");
+      fail("Should have failed and been caught as an exception");
     } catch (final IllegalArgumentException e) {
       assertThat(e.getMessage(), is(Error.SEGMENTS_UNDERFLOW.getMessageFormat()));
       throw e;


### PR DESCRIPTION
- Removes `SEGMENTS_UNDERFLOW` check for `InterledgerAddressPrefix` as this cannot be reached.
- Adds explicit test cases for `InterledgerAddress#of` and `InterledgerAddressPrefix#of`.
- Update error message if a corner case slips through the checks and ask users to report a bug.

Signed-off-by: sudheesh001 <sudheesh1995@outlook.com>