### PR TITLE
Using StandardCharsets instead of Charset.forName for US-ASCII

### DIFF
--- a/stream-parent/stream-core/src/main/java/org/interledger/stream/StreamUtils.java
+++ b/stream-parent/stream-core/src/main/java/org/interledger/stream/StreamUtils.java
@@ -8,6 +8,7 @@ import com.google.common.hash.Hashing;
 import com.google.common.primitives.UnsignedLong;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 import javax.crypto.SecretKey;
@@ -22,7 +23,7 @@ public class StreamUtils {
    * The string "ilp_stream_fulfillment" is encoded as UTF-8 or ASCII (the byte representation is the same with both
    * encodings).
    */
-  private static final byte[] ILP_STREAM_FULFILLMENT = "ilp_stream_fulfillment".getBytes(Charset.forName("UTF-8"));
+  private static final byte[] ILP_STREAM_FULFILLMENT = "ilp_stream_fulfillment".getBytes(StandardCharsets.UTF_8);
 
   private static final String HMAC_SHA256_ALG_NAME = "HmacSHA256";
 

--- a/stream-parent/stream-core/src/main/java/org/interledger/stream/crypto/JavaxStreamEncryptionService.java
+++ b/stream-parent/stream-core/src/main/java/org/interledger/stream/crypto/JavaxStreamEncryptionService.java
@@ -5,6 +5,7 @@ import com.google.common.hash.Hashing;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -26,7 +27,7 @@ public class JavaxStreamEncryptionService implements StreamEncryptionService {
 
   private static final String CIPHER_ALGO = "AES/GCM/NoPadding";
 
-  private static final byte[] ENCRYPTION_KEY_STRING = "ilp_stream_encryption".getBytes(Charset.forName("US-ASCII"));
+  private static final byte[] ENCRYPTION_KEY_STRING = "ilp_stream_encryption".getBytes(StandardCharsets.US_ASCII);
 
   /**
    * For GCM a 12 byte random byte-array is recommend by NIST because it's faster and more secure (See page 8 in the PDF


### PR DESCRIPTION
Signed-off-by: Sudheesh Singanamalla <sudheesh@cs.washington.edu>