### PR TITLE
Df/259 remove optional operator2

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Next, add the following Maven dependency:
   <dependency>
     <groupId>org.interledger</groupId>
     <artifactId>java-ilp-core</artifactId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.19-SNAPSHOT</version>
   </dependency>
   ...
 </dependencies>
@@ -77,7 +77,7 @@ Next, import this library as a dependency, like this:
 ```
 dependencies {
     ...
-    compile group: 'org.interledger', name: 'java-ilp-core', version: '0.18-SNAPSHOT'
+    compile group: 'org.interledger', name: 'java-ilp-core', version: '0.19-SNAPSHOT'
     ...
 }
 ```

--- a/btp-core/pom.xml
+++ b/btp-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>quilt-parent</artifactId>
     <groupId>org.interledger</groupId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.19-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/codecs-parent/codecs-btp/pom.xml
+++ b/codecs-parent/codecs-btp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.interledger</groupId>
     <artifactId>codecs-parent</artifactId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.19-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/codecs-parent/codecs-framework/pom.xml
+++ b/codecs-parent/codecs-framework/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.interledger</groupId>
     <artifactId>codecs-parent</artifactId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.19-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/codecs-parent/codecs-ildcp/pom.xml
+++ b/codecs-parent/codecs-ildcp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.interledger</groupId>
         <artifactId>codecs-parent</artifactId>
-        <version>0.18-SNAPSHOT</version>
+        <version>0.19-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/codecs-parent/codecs-ilp/pom.xml
+++ b/codecs-parent/codecs-ilp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.interledger</groupId>
         <artifactId>codecs-parent</artifactId>
-        <version>0.18-SNAPSHOT</version>
+        <version>0.19-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/codecs-parent/codecs-stream/pom.xml
+++ b/codecs-parent/codecs-stream/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.interledger</groupId>
     <artifactId>codecs-parent</artifactId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.19-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/codecs-parent/pom.xml
+++ b/codecs-parent/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.interledger</groupId>
     <artifactId>quilt-parent</artifactId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.19-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/ildcp-core/pom.xml
+++ b/ildcp-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>quilt-parent</artifactId>
     <groupId>org.interledger</groupId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.19-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/ilp-core/pom.xml
+++ b/ilp-core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.interledger</groupId>
     <artifactId>quilt-parent</artifactId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.19-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/jackson-datatypes/README.md
+++ b/jackson-datatypes/README.md
@@ -11,7 +11,7 @@ to your project:
 <dependency>
   <groupId>org.interledger.quilt.jackson</groupId>
   <artifactId>jackson-datatypes</artifactId>
-  <version>0.18-SNAPSHOT</version>
+  <version>0.19-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/jackson-datatypes/pom.xml
+++ b/jackson-datatypes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.interledger</groupId>
     <artifactId>quilt-parent</artifactId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.19-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/link-parent/link-core/pom.xml
+++ b/link-parent/link-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.interledger</groupId>
     <artifactId>link-parent</artifactId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.19-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/link-parent/link-core/src/main/java/org/interledger/link/AbstractLink.java
+++ b/link-parent/link-core/src/main/java/org/interledger/link/AbstractLink.java
@@ -23,7 +23,7 @@ public abstract class AbstractLink<L extends LinkSettings> implements Link<L> {
    * not yet populated when this client is constructed (e.g, IL-DCP). Thus, the value is optional to accommodate these
    * cases.
    */
-  private final Supplier<Optional<InterledgerAddress>> operatorAddressSupplier;
+  private final Supplier<InterledgerAddress> operatorAddressSupplier;
 
   /**
    * A typed representation of the configuration options passed-into this ledger link.
@@ -38,12 +38,14 @@ public abstract class AbstractLink<L extends LinkSettings> implements Link<L> {
   /**
    * Required-args Constructor.
    *
-   * @param operatorAddressSupplier A {@link Supplier} that supplies the optionally-present operator address of the node
-   *                                operating this Link (note this is optional to support IL-DCP).
+   * @param operatorAddressSupplier A supplier for the ILP address of this node operating this Link. This value may be
+   *                                uninitialized, for example, in cases where the Link obtains its address from a
+   *                                parent node using IL-DCP. If an ILP address has not been assigned, or it has not
+   *                                been obtained via IL-DCP, then this value will by default be {@link Link#SELF}.
    * @param linkSettings            A {@link L} that specified ledger link options.
    */
   protected AbstractLink(
-      final Supplier<Optional<InterledgerAddress>> operatorAddressSupplier,
+      final Supplier<InterledgerAddress> operatorAddressSupplier,
       final L linkSettings
   ) {
     this.operatorAddressSupplier = Objects.requireNonNull(operatorAddressSupplier);
@@ -66,7 +68,7 @@ public abstract class AbstractLink<L extends LinkSettings> implements Link<L> {
   }
 
   @Override
-  public Supplier<Optional<InterledgerAddress>> getOperatorAddressSupplier() {
+  public Supplier<InterledgerAddress> getOperatorAddressSupplier() {
     return operatorAddressSupplier;
   }
 

--- a/link-parent/link-core/src/main/java/org/interledger/link/AbstractStatefulLink.java
+++ b/link-parent/link-core/src/main/java/org/interledger/link/AbstractStatefulLink.java
@@ -9,7 +9,6 @@ import org.interledger.link.events.LinkDisconnectedEvent;
 import com.google.common.eventbus.EventBus;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
@@ -28,12 +27,15 @@ public abstract class AbstractStatefulLink<L extends LinkSettings>
   /**
    * Required-args Constructor.
    *
-   * @param operatorAddressSupplier    A {@link Supplier} for the ILP address of the node operating this link.
+   * @param operatorAddressSupplier    A supplier for the ILP address of this node operating this Link. This value may
+   *                                   be uninitialized, for example, in cases where the Link obtains its address from a
+   *                                   parent node using IL-DCP. If an ILP address has not been assigned, or it has not
+   *                                   been obtained via IL-DCP, then this value will by default be {@link Link#SELF}.
    * @param linkSettings               A {@link L} that specified ledger link options.
    * @param linkConnectionEventEmitter A {@link LinkConnectionEventEmitter} that is used to emit events from this link.
    */
   protected AbstractStatefulLink(
-      final Supplier<Optional<InterledgerAddress>> operatorAddressSupplier,
+      final Supplier<InterledgerAddress> operatorAddressSupplier,
       final L linkSettings,
       final LinkConnectionEventEmitter linkConnectionEventEmitter
   ) {
@@ -187,7 +189,7 @@ public abstract class AbstractStatefulLink<L extends LinkSettings>
    * @return A {@link String}.
    */
   private String operatorAddressAsString() {
-    return this.getOperatorAddressSupplier().get().map(InterledgerAddress::getValue).orElse("unset");
+    return this.getOperatorAddressSupplier().get().getValue();
   }
 
 

--- a/link-parent/link-core/src/main/java/org/interledger/link/Link.java
+++ b/link-parent/link-core/src/main/java/org/interledger/link/Link.java
@@ -39,12 +39,16 @@ public interface Link<L extends LinkSettings> extends LinkSender {
   void setLinkId(LinkId linkId);
 
   /**
-   * A supplier for the ILP address of this node operator. This value may be empty, for example, in cases where the
-   * Link obtains its address from a parent node using IL-DCP.
+   * A supplier for the ILP address of this node operating this Link. This value may be uninitialized, for example, in
+   * cases where the Link obtains its address from a parent node using IL-DCP. If an ILP address has not been assigned,
+   * or it has not been obtained via IL-DCP, then this value will by default be {@link Link#SELF}.
    *
-   * @return A {@link Supplier} of an optioanally-present {@link InterledgerAddress}.
+   * @return A {@link Supplier} of the {@link InterledgerAddress} that represents the address of the node operating this
+   *     Link.
    */
-  Supplier<Optional<InterledgerAddress>> getOperatorAddressSupplier();
+  default Supplier<InterledgerAddress> getOperatorAddressSupplier() {
+    return () -> SELF;
+  }
 
   /**
    * The settings for this Link.

--- a/link-parent/link-core/src/main/java/org/interledger/link/LinkFactory.java
+++ b/link-parent/link-core/src/main/java/org/interledger/link/LinkFactory.java
@@ -2,7 +2,6 @@ package org.interledger.link;
 
 import org.interledger.core.InterledgerAddress;
 
-import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -13,13 +12,15 @@ public interface LinkFactory {
   /**
    * Construct a new instance of {@link Link} using the supplied inputs.
    *
-   * @param operatorAddressSupplier A {@link Supplier} that supplies the ILP address of the Connector operating this
-   *                                link.
+   * @param operatorAddressSupplier A supplier for the ILP address of this node operating this Link. This value may be
+   *                                uninitialized, for example, in cases where the Link obtains its address from a
+   *                                parent node using IL-DCP. If an ILP address has not been assigned, or it has not
+   *                                been obtained via IL-DCP, then this value will by default be {@link Link#SELF}.
    * @param linkSettings            An instance of {@link LinkSettings} to initialize this link from.
    *
    * @return A newly constructed instance of {@link Link}.
    */
-  Link<?> constructLink(Supplier<Optional<InterledgerAddress>> operatorAddressSupplier, LinkSettings linkSettings);
+  Link<?> constructLink(Supplier<InterledgerAddress> operatorAddressSupplier, LinkSettings linkSettings);
 
   /**
    * Helper method to apply custom settings on a per-link-type basis.
@@ -45,7 +46,10 @@ public interface LinkFactory {
    * Construct a new instance of {@link Link} using the supplied inputs.
    *
    * @param $                       A {@link Class} to satisfy Java generics.
-   * @param operatorAddressSupplier A {@link Supplier} for the address of the node operating this factory.
+   * @param operatorAddressSupplier A supplier for the ILP address of this node operating this Link. This value may be
+   *                                uninitialized, for example, in cases where the Link obtains its address from a *
+   *                                parent node using IL-DCP. If an ILP address has not been assigned, or it has not
+   *                                been obtained via IL-DCP, then this value will by default be {@link Link#SELF}.
    * @param linkSettings            A {@link LinkSettings} to use in order to construct a {@link Link}.
    * @param <LS>                    A type that extends {@link LinkSettings}.
    * @param <L>                     A type that extends {@link Link}.
@@ -53,7 +57,7 @@ public interface LinkFactory {
    * @return An instance of {@link L}.
    */
   default <LS extends LinkSettings, L extends Link<LS>> L constructLink(
-      final Class<L> $, Supplier<Optional<InterledgerAddress>> operatorAddressSupplier, final LS linkSettings
+      final Class<L> $, Supplier<InterledgerAddress> operatorAddressSupplier, final LS linkSettings
   ) {
     return (L) this.constructLink(operatorAddressSupplier, linkSettings);
   }

--- a/link-parent/link-core/src/main/java/org/interledger/link/LoopbackLink.java
+++ b/link-parent/link-core/src/main/java/org/interledger/link/LoopbackLink.java
@@ -32,12 +32,15 @@ public class LoopbackLink extends AbstractLink<LinkSettings> implements Link<Lin
   /**
    * Required-Args Constructor.
    *
-   * @param operatorAddressSupplier A {@link Supplier} of the ILP address for the node that's operating this Link.
+   * @param operatorAddressSupplier A supplier for the ILP address of this node operating this Link. This value may be
+   *                                uninitialized, for example, in cases where the Link obtains its address from a
+   *                                parent node using IL-DCP. If an ILP address has not been assigned, or it has not
+   *                                been obtained via IL-DCP, then this value will by default be {@link Link#SELF}.
    * @param linkSettings            A {@link LinkSettings} for this Link.
    * @param packetRejector          A {@link PacketRejector} to aid in rejecting packets in a uniform manner.
    */
   public LoopbackLink(
-      final Supplier<Optional<InterledgerAddress>> operatorAddressSupplier,
+      final Supplier<InterledgerAddress> operatorAddressSupplier,
       final LinkSettings linkSettings,
       final PacketRejector packetRejector
   ) {

--- a/link-parent/link-core/src/main/java/org/interledger/link/LoopbackLinkFactory.java
+++ b/link-parent/link-core/src/main/java/org/interledger/link/LoopbackLinkFactory.java
@@ -4,7 +4,6 @@ import org.interledger.core.InterledgerAddress;
 import org.interledger.link.exceptions.LinkException;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -26,10 +25,16 @@ public class LoopbackLinkFactory implements LinkFactory {
   /**
    * Construct a new instance of {@link Link} using the supplied inputs.
    *
+   * @param operatorAddressSupplier A supplier for the ILP address of this node operating this Link. This value may be
+   *                                uninitialized, for example, in cases where the Link obtains its address from a
+   *                                parent node using IL-DCP. If an ILP address has not been assigned, or it has not
+   *                                been obtained via IL-DCP, then this value will by default be {@link Link#SELF}.
+   * @param linkSettings            An instance of {@link LinkSettings} to initialize this link from.
+   *
    * @return A newly constructed instance of {@link Link}.
    */
   public Link<?> constructLink(
-      final Supplier<Optional<InterledgerAddress>> operatorAddressSupplier, final LinkSettings linkSettings
+      final Supplier<InterledgerAddress> operatorAddressSupplier, final LinkSettings linkSettings
   ) {
     Objects.requireNonNull(operatorAddressSupplier, "operatorAddressSupplier must not be null");
     Objects.requireNonNull(linkSettings, "linkSettings must not be null");

--- a/link-parent/link-core/src/main/java/org/interledger/link/PacketRejector.java
+++ b/link-parent/link-core/src/main/java/org/interledger/link/PacketRejector.java
@@ -9,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -17,19 +16,16 @@ import java.util.function.Supplier;
  */
 public class PacketRejector {
 
-  public static final InterledgerAddress UNSET_OPERATOR_ADDRESS =
-      InterledgerAddress.of(InterledgerAddress.AllocationScheme.PRIVATE.getValue() + ".unset-operator-address");
-
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-  private final Supplier<Optional<InterledgerAddress>> operatorAddressSupplier;
+  private final Supplier<InterledgerAddress> operatorAddressSupplier;
 
   /**
    * Required-args Constructor.
    *
    * @param operatorAddressSupplier A {@link Supplier} of the ILP address for the node that's operating this Link.
    */
-  public PacketRejector(final Supplier<Optional<InterledgerAddress>> operatorAddressSupplier) {
+  public PacketRejector(final Supplier<InterledgerAddress> operatorAddressSupplier) {
     this.operatorAddressSupplier = Objects
         .requireNonNull(operatorAddressSupplier, "operatorAddressSupplier must not be null");
   }
@@ -55,7 +51,7 @@ public class PacketRejector {
 
     // Reject.
     final InterledgerRejectPacket rejectPacket = InterledgerRejectPacket.builder()
-        .triggeredBy(operatorAddressSupplier.get().orElse(UNSET_OPERATOR_ADDRESS))
+        .triggeredBy(operatorAddressSupplier.get())
         .code(errorCode)
         .message(errorMessage)
         .build();

--- a/link-parent/link-core/src/main/java/org/interledger/link/PingLoopbackLink.java
+++ b/link-parent/link-core/src/main/java/org/interledger/link/PingLoopbackLink.java
@@ -1,7 +1,5 @@
 package org.interledger.link;
 
-import static org.interledger.link.PacketRejector.UNSET_OPERATOR_ADDRESS;
-
 import org.interledger.core.InterledgerAddress;
 import org.interledger.core.InterledgerCondition;
 import org.interledger.core.InterledgerErrorCode;
@@ -14,7 +12,6 @@ import org.interledger.link.exceptions.LinkHandlerAlreadyRegisteredException;
 
 import java.util.Base64;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -38,11 +35,14 @@ public class PingLoopbackLink extends AbstractLink<LinkSettings> implements Link
   /**
    * Required-Args Constructor.
    *
-   * @param operatorAddressSupplier A {@link Supplier} of the ILP address for the node that's operating this Link.
-   * @param linkSettings            A {@link LinkSettings} for this Link.
+   * @param operatorAddressSupplier A supplier for the ILP address of this node operating this Link. This value may be
+   *                                uninitialized, for example, in cases where the Link obtains its address from a
+   *                                parent node using IL-DCP. If an ILP address has not been assigned, or it has not
+   *                                been obtained via IL-DCP, then this value will by default be {@link Link#SELF}.
+   * @param linkSettings            An instance of {@link LinkSettings} to initialize this link from.
    */
   public PingLoopbackLink(
-      final Supplier<Optional<InterledgerAddress>> operatorAddressSupplier, final LinkSettings linkSettings
+      final Supplier<InterledgerAddress> operatorAddressSupplier, final LinkSettings linkSettings
   ) {
     super(operatorAddressSupplier, linkSettings);
   }
@@ -66,7 +66,7 @@ public class PingLoopbackLink extends AbstractLink<LinkSettings> implements Link
     } else {
       // Reject.
       final InterledgerRejectPacket rejectPacket = InterledgerRejectPacket.builder()
-          .triggeredBy(getOperatorAddressSupplier().get().orElse(UNSET_OPERATOR_ADDRESS))
+          .triggeredBy(getOperatorAddressSupplier().get())
           .code(InterledgerErrorCode.F00_BAD_REQUEST)
           .message("Invalid Ping Protocol Condition")
           .build();

--- a/link-parent/link-core/src/main/java/org/interledger/link/PingLoopbackLinkFactory.java
+++ b/link-parent/link-core/src/main/java/org/interledger/link/PingLoopbackLinkFactory.java
@@ -4,7 +4,6 @@ import org.interledger.core.InterledgerAddress;
 import org.interledger.link.exceptions.LinkException;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -18,10 +17,16 @@ public class PingLoopbackLinkFactory implements LinkFactory {
   /**
    * Construct a new instance of {@link Link} using the supplied inputs.
    *
+   * @param operatorAddressSupplier A supplier for the ILP address of this node operating this Link. This value may be
+   *                                uninitialized, for example, in cases where the Link obtains its address from a
+   *                                parent node using IL-DCP. If an ILP address has not been assigned, or it has not
+   *                                been obtained via IL-DCP, then this value will by default be {@link Link#SELF}.
+   * @param linkSettings            An instance of {@link LinkSettings} to initialize this link from.
+   *
    * @return A newly constructed instance of {@link Link}.
    */
   public Link<?> constructLink(
-      final Supplier<Optional<InterledgerAddress>> operatorAddressSupplier, final LinkSettings linkSettings
+      final Supplier<InterledgerAddress> operatorAddressSupplier, final LinkSettings linkSettings
   ) {
     Objects.requireNonNull(operatorAddressSupplier, "operatorAddressSupplier must not be null");
     Objects.requireNonNull(linkSettings, "linkSettings must not be null");

--- a/link-parent/link-core/src/test/java/org/interledger/link/AbstractLinkTest.java
+++ b/link-parent/link-core/src/test/java/org/interledger/link/AbstractLinkTest.java
@@ -35,7 +35,7 @@ public class AbstractLinkTest {
     MockitoAnnotations.initMocks(this);
 
     this.link = new TestAbstractLink(
-        () -> Optional.of(OPERATOR_ADDRESS),
+        () -> OPERATOR_ADDRESS,
         LINK_SETTINGS
     );
     this.link.setLinkId(LINK_ID);
@@ -44,7 +44,7 @@ public class AbstractLinkTest {
   @Test(expected = IllegalStateException.class)
   public void getLinkIdWhenNull() {
     this.link = new TestAbstractLink(
-        () -> Optional.of(OPERATOR_ADDRESS),
+        () -> OPERATOR_ADDRESS,
         LinkSettings.builder().linkType(LinkType.of("foo")).build()
     );
     try {
@@ -73,7 +73,7 @@ public class AbstractLinkTest {
 
   @Test
   public void getOperatorAddressSupplier() {
-    assertThat(link.getOperatorAddressSupplier().get().get()).isEqualTo(OPERATOR_ADDRESS);
+    assertThat(link.getOperatorAddressSupplier().get()).isEqualTo(OPERATOR_ADDRESS);
   }
 
   @Test
@@ -117,7 +117,7 @@ public class AbstractLinkTest {
    */
   private class TestAbstractLink extends AbstractLink {
 
-    private TestAbstractLink(Supplier operatorAddressSupplier, LinkSettings linkSettings) {
+    private TestAbstractLink(Supplier<InterledgerAddress> operatorAddressSupplier, LinkSettings linkSettings) {
       super(operatorAddressSupplier, linkSettings);
     }
 

--- a/link-parent/link-core/src/test/java/org/interledger/link/AbstractStatefulLinkTest.java
+++ b/link-parent/link-core/src/test/java/org/interledger/link/AbstractStatefulLinkTest.java
@@ -62,7 +62,7 @@ public class AbstractStatefulLinkTest {
     this.onDisconnectCalled = new AtomicBoolean();
 
     link = new TestAbstractStatefulLink(
-        () -> Optional.of(OPERATOR_ADDRESS),
+        () -> OPERATOR_ADDRESS,
         LINK_SETTINGS,
         linkConnectionEventEmitterMock
     );
@@ -72,7 +72,7 @@ public class AbstractStatefulLinkTest {
   @Test(expected = IllegalStateException.class)
   public void getLinkIdWhenNull() {
     link = new TestAbstractStatefulLink(
-        () -> Optional.of(OPERATOR_ADDRESS),
+        () -> OPERATOR_ADDRESS,
         LINK_SETTINGS,
         linkConnectionEventEmitterMock
     );
@@ -103,7 +103,7 @@ public class AbstractStatefulLinkTest {
 
   @Test
   public void getOperatorAddressSupplier() {
-    assertThat(link.getOperatorAddressSupplier().get().get()).isEqualTo(OPERATOR_ADDRESS);
+    assertThat(link.getOperatorAddressSupplier().get()).isEqualTo(OPERATOR_ADDRESS);
   }
 
   @Test
@@ -215,7 +215,7 @@ public class AbstractStatefulLinkTest {
     final EventBus eventBus = new EventBus();
 
     this.link = new TestAbstractStatefulLink(
-        () -> Optional.of(OPERATOR_ADDRESS),
+        () -> OPERATOR_ADDRESS,
         LINK_SETTINGS,
         new EventBusConnectionEventEmitter(eventBus)
     );
@@ -270,7 +270,7 @@ public class AbstractStatefulLinkTest {
     final EventBus eventBus = new EventBus();
 
     link = new AbstractStatefulLink(
-        () -> Optional.of(OPERATOR_ADDRESS),
+        () -> OPERATOR_ADDRESS,
         LINK_SETTINGS,
         new EventBusConnectionEventEmitter(eventBus)
     ) {
@@ -329,7 +329,8 @@ public class AbstractStatefulLinkTest {
   private class TestAbstractStatefulLink extends AbstractStatefulLink {
 
     private TestAbstractStatefulLink(
-        Supplier operatorAddressSupplier, LinkSettings linkSettings,
+        Supplier<InterledgerAddress> operatorAddressSupplier,
+        LinkSettings linkSettings,
         LinkConnectionEventEmitter linkConnectionEventEmitter
     ) {
       super(operatorAddressSupplier, linkSettings, linkConnectionEventEmitter);

--- a/link-parent/link-core/src/test/java/org/interledger/link/LoopbackLinkFactoryTest.java
+++ b/link-parent/link-core/src/test/java/org/interledger/link/LoopbackLinkFactoryTest.java
@@ -67,7 +67,7 @@ public class LoopbackLinkFactoryTest {
   @Test(expected = NullPointerException.class)
   public void constructLinkWithNullLinkSettings() {
     try {
-      loopbackLinkFactory.constructLink(() -> Optional.of(OPERATOR_ADDRESS), null);
+      loopbackLinkFactory.constructLink(() -> OPERATOR_ADDRESS, null);
       fail();
     } catch (NullPointerException e) {
       assertThat(e.getMessage()).isEqualTo("linkSettings must not be null");
@@ -81,7 +81,7 @@ public class LoopbackLinkFactoryTest {
       LinkSettings linkSettings = LinkSettings.builder()
           .linkType(LinkType.of("foo"))
           .build();
-      loopbackLinkFactory.constructLink(() -> Optional.of(OPERATOR_ADDRESS), linkSettings);
+      loopbackLinkFactory.constructLink(() -> OPERATOR_ADDRESS, linkSettings);
       fail();
     } catch (NullPointerException e) {
       assertThat(e.getMessage()).isEqualTo("LinkType not supported by this factory. linkType=LinkType(FOO)");
@@ -94,7 +94,7 @@ public class LoopbackLinkFactoryTest {
     LinkSettings linkSettings = LinkSettings.builder()
         .linkType(LoopbackLink.LINK_TYPE)
         .build();
-    Link<?> link = loopbackLinkFactory.constructLink(() -> Optional.of(OPERATOR_ADDRESS), linkSettings);
+    Link<?> link = loopbackLinkFactory.constructLink(() -> OPERATOR_ADDRESS, linkSettings);
     link.setLinkId(linkId);
     assertThat(link.getLinkId()).isEqualTo(linkId);
   }

--- a/link-parent/link-core/src/test/java/org/interledger/link/LoopbackLinkTest.java
+++ b/link-parent/link-core/src/test/java/org/interledger/link/LoopbackLinkTest.java
@@ -35,10 +35,10 @@ public class LoopbackLinkTest {
 
   @Before
   public void setUp() {
-    this.packetRejector = new PacketRejector(() -> Optional.of(OPERATOR_ADDRESS));
+    this.packetRejector = new PacketRejector(() -> OPERATOR_ADDRESS);
 
     this.link = new LoopbackLink(
-        () -> Optional.of(OPERATOR_ADDRESS),
+        () -> OPERATOR_ADDRESS,
         LinkSettings.builder().linkType(LoopbackLink.LINK_TYPE).build(),
         packetRejector
     );
@@ -68,7 +68,7 @@ public class LoopbackLinkTest {
   @Test
   public void sendPacket() {
     this.link = new LoopbackLink(
-        () -> Optional.of(OPERATOR_ADDRESS),
+        () -> OPERATOR_ADDRESS,
         LinkSettings.builder().linkType(LoopbackLink.LINK_TYPE).build(),
         packetRejector
     );
@@ -92,7 +92,7 @@ public class LoopbackLinkTest {
     final Map<String, String> customSettings = Maps.newHashMap();
     customSettings.put(SIMULATED_REJECT_ERROR_CODE, InterledgerErrorCode.T02_PEER_BUSY_CODE);
     this.link = new LoopbackLink(
-        () -> Optional.of(OPERATOR_ADDRESS),
+        () -> OPERATOR_ADDRESS,
         LinkSettings.builder().linkType(LoopbackLink.LINK_TYPE).customSettings(customSettings).build(),
         packetRejector
     );
@@ -114,7 +114,7 @@ public class LoopbackLinkTest {
     final Map<String, String> customSettings = Maps.newHashMap();
     customSettings.put(SIMULATED_REJECT_ERROR_CODE, InterledgerErrorCode.T99_APPLICATION_ERROR_CODE);
     this.link = new LoopbackLink(
-        () -> Optional.of(OPERATOR_ADDRESS),
+        () -> OPERATOR_ADDRESS,
         LinkSettings.builder().linkType(LoopbackLink.LINK_TYPE).customSettings(customSettings).build(),
         packetRejector
     );

--- a/link-parent/link-core/src/test/java/org/interledger/link/PacketRejectorTest.java
+++ b/link-parent/link-core/src/test/java/org/interledger/link/PacketRejectorTest.java
@@ -33,7 +33,7 @@ public class PacketRejectorTest {
 
   @Before
   public void setup() {
-    this.packetRejector = new PacketRejector(() -> Optional.of(OPERATOR_ADDRESS));
+    this.packetRejector = new PacketRejector(() -> OPERATOR_ADDRESS);
   }
 
   @Test(expected = NullPointerException.class)

--- a/link-parent/link-core/src/test/java/org/interledger/link/PingLoopbackLinkFactoryTest.java
+++ b/link-parent/link-core/src/test/java/org/interledger/link/PingLoopbackLinkFactoryTest.java
@@ -52,7 +52,7 @@ public class PingLoopbackLinkFactoryTest {
   @Test(expected = NullPointerException.class)
   public void constructLinkWithNullLinkSettings() {
     try {
-      pingLoopbackLinkFactory.constructLink(() -> Optional.of(OPERATOR_ADDRESS), null);
+      pingLoopbackLinkFactory.constructLink(() -> OPERATOR_ADDRESS, null);
       fail();
     } catch (NullPointerException e) {
       assertThat(e.getMessage()).isEqualTo("linkSettings must not be null");
@@ -66,7 +66,7 @@ public class PingLoopbackLinkFactoryTest {
       LinkSettings linkSettings = LinkSettings.builder()
           .linkType(LinkType.of("foo"))
           .build();
-      pingLoopbackLinkFactory.constructLink(() -> Optional.of(OPERATOR_ADDRESS), linkSettings);
+      pingLoopbackLinkFactory.constructLink(() -> OPERATOR_ADDRESS, linkSettings);
       fail();
     } catch (NullPointerException e) {
       assertThat(e.getMessage()).isEqualTo("LinkType not supported by this factory. linkType=LinkType(FOO)");
@@ -79,7 +79,7 @@ public class PingLoopbackLinkFactoryTest {
     LinkSettings linkSettings = LinkSettings.builder()
         .linkType(PingLoopbackLink.LINK_TYPE)
         .build();
-    Link<?> link = pingLoopbackLinkFactory.constructLink(() -> Optional.of(OPERATOR_ADDRESS), linkSettings);
+    Link<?> link = pingLoopbackLinkFactory.constructLink(() -> OPERATOR_ADDRESS, linkSettings);
     link.setLinkId(LINK_ID);
     assertThat(link.getLinkId()).isEqualTo(LINK_ID);
   }

--- a/link-parent/link-core/src/test/java/org/interledger/link/PingLoopbackLinkTest.java
+++ b/link-parent/link-core/src/test/java/org/interledger/link/PingLoopbackLinkTest.java
@@ -48,7 +48,7 @@ public class PingLoopbackLinkTest {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    this.link = new PingLoopbackLink(() -> Optional.of(OPERATOR_ADDRESS), linkSettingsMock);
+    this.link = new PingLoopbackLink(() -> OPERATOR_ADDRESS, linkSettingsMock);
   }
 
   @Test(expected = RuntimeException.class)

--- a/link-parent/link-ilp-over-http/pom.xml
+++ b/link-parent/link-ilp-over-http/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.interledger</groupId>
     <artifactId>link-parent</artifactId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.19-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/link-parent/link-ilp-over-http/src/main/java/org/interledger/link/http/IlpOverHttpLink.java
+++ b/link-parent/link-ilp-over-http/src/main/java/org/interledger/link/http/IlpOverHttpLink.java
@@ -79,8 +79,10 @@ public class IlpOverHttpLink extends AbstractLink<IlpOverHttpLinkSettings> imple
   /**
    * Required-args Constructor.
    *
-   * @param operatorAddressSupplier A {@link Supplier} of an optionally present {@link InterledgerAddress} for the
-   *                                operator of this link.
+   * @param operatorAddressSupplier A supplier for the ILP address of this node operating this Link. This value may be
+   *                                uninitialized, for example, in cases where the Link obtains its address from a
+   *                                parent node using IL-DCP. If an ILP address has not been assigned, or it has not
+   *                                been obtained via IL-DCP, then this value will by default be {@link Link#SELF}.
    * @param ilpOverHttpLinkSettings A {@link IlpOverHttpLinkSettings} that specified ledger link options.
    * @param okHttpClient            A {@link OkHttpClient} to use to communicate with the remote ILP-over-HTTP
    *                                endpoint.
@@ -91,7 +93,7 @@ public class IlpOverHttpLink extends AbstractLink<IlpOverHttpLinkSettings> imple
    *                                authenticated calls to the remote HTTP endpoint.
    */
   public IlpOverHttpLink(
-      final Supplier<Optional<InterledgerAddress>> operatorAddressSupplier,
+      final Supplier<InterledgerAddress> operatorAddressSupplier,
       final IlpOverHttpLinkSettings ilpOverHttpLinkSettings,
       final OkHttpClient okHttpClient,
       final ObjectMapper objectMapper,
@@ -233,9 +235,7 @@ public class IlpOverHttpLink extends AbstractLink<IlpOverHttpLinkSettings> imple
         .add(PRAGMA, "no-cache");
 
     // Set the Operator Address header, if present.
-    getOperatorAddressSupplier().get().ifPresent(
-        operatorAddress -> headers
-            .set(IlpOverHttpConstants.ILP_OPERATOR_ADDRESS_VALUE, operatorAddress.getValue()));
+    headers.set(IlpOverHttpConstants.ILP_OPERATOR_ADDRESS_VALUE, getOperatorAddressSupplier().get().getValue());
 
     headers.add(HttpHeaders.AUTHORIZATION, BEARER + this.authTokenSupplier.get());
 

--- a/link-parent/link-ilp-over-http/src/main/java/org/interledger/link/http/IlpOverHttpLinkFactory.java
+++ b/link-parent/link-ilp-over-http/src/main/java/org/interledger/link/http/IlpOverHttpLinkFactory.java
@@ -6,7 +6,6 @@ import org.interledger.link.Link;
 import org.interledger.link.LinkFactory;
 import org.interledger.link.LinkSettings;
 import org.interledger.link.LinkType;
-import org.interledger.link.events.LinkConnectionEventEmitter;
 import org.interledger.link.http.auth.BearerTokenSupplier;
 import org.interledger.link.http.auth.Decryptor;
 import org.interledger.link.http.auth.JwtHs256BearerTokenSupplier;
@@ -17,7 +16,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.OkHttpClient;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -25,18 +23,26 @@ import java.util.function.Supplier;
  */
 public class IlpOverHttpLinkFactory implements LinkFactory {
 
-  private final LinkConnectionEventEmitter linkConnectionEventEmitter;
   private final OkHttpClient okHttpClient;
   private final Decryptor decryptor;
   private final ObjectMapper objectMapper;
   private final CodecContext ilpCodecContext;
 
+  /**
+   * Required-args Constructor.
+   *
+   * @param okHttpClient    An {@link OkHttpClient} that is used to send data to the remote peer for this {@link Link}.
+   * @param decryptor       A {@link Decryptor} that is used to decrypt sensitive data found in any {@link LinkSettings}
+   *                        object used to construct a new {@link Link}.
+   * @param objectMapper    An {@link ObjectMapper} used to (de)serialize JSON data.
+   * @param ilpCodecContext A {@link CodecContext} that can encode and decode ASN.1 OER payloads.
+   */
   public IlpOverHttpLinkFactory(
-      final LinkConnectionEventEmitter linkConnectionEventEmitter, final OkHttpClient okHttpClient,
+      final OkHttpClient okHttpClient,
       final Decryptor decryptor,
-      final ObjectMapper objectMapper, final CodecContext ilpCodecContext
+      final ObjectMapper objectMapper,
+      final CodecContext ilpCodecContext
   ) {
-    this.linkConnectionEventEmitter = Objects.requireNonNull(linkConnectionEventEmitter);
     this.okHttpClient = Objects.requireNonNull(okHttpClient);
     this.decryptor = Objects.requireNonNull(decryptor);
     this.objectMapper = Objects.requireNonNull(objectMapper);
@@ -46,10 +52,16 @@ public class IlpOverHttpLinkFactory implements LinkFactory {
   /**
    * Construct a new instance of {@link Link} using the supplied inputs.
    *
+   * @param operatorAddressSupplier A supplier for the ILP address of this node operating this Link. This value may be
+   *                                uninitialized, for example, in cases where the Link obtains its address from a *
+   *                                parent node using IL-DCP. If an ILP address has not been assigned, or it has not
+   *                                been obtained via IL-DCP, then this value will by default be {@link Link#SELF}.
+   * @param linkSettings            A {@link LinkSettings} that is used to construct an ILP-over-HTTP {@link Link}.
+   *
    * @return A newly constructed instance of {@link Link}.
    */
   public Link<?> constructLink(
-      final Supplier<Optional<InterledgerAddress>> operatorAddressSupplier, final LinkSettings linkSettings
+      final Supplier<InterledgerAddress> operatorAddressSupplier, final LinkSettings linkSettings
   ) {
     Objects.requireNonNull(linkSettings);
 

--- a/link-parent/pom.xml
+++ b/link-parent/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>quilt-parent</artifactId>
     <groupId>org.interledger</groupId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.19-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.interledger</groupId>
   <artifactId>quilt-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.18-SNAPSHOT</version>
+  <version>0.19-SNAPSHOT</version>
 
   <name>Hyperledger Quilt Parent</name>
   <description>Parent project for Hyperledger Quilt modules.</description>

--- a/stream-parent/pom.xml
+++ b/stream-parent/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.interledger</groupId>
     <artifactId>quilt-parent</artifactId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.19-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/stream-parent/stream-client/pom.xml
+++ b/stream-parent/stream-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.interledger</groupId>
     <artifactId>stream-parent</artifactId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.19-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/stream-parent/stream-client/src/test/java/org/interledger/stream/sender/SimpleStreamSenderIT.java
+++ b/stream-parent/stream-client/src/test/java/org/interledger/stream/sender/SimpleStreamSenderIT.java
@@ -2,6 +2,7 @@ package org.interledger.stream.sender;
 
 import static okhttp3.CookieJar.NO_COOKIES;
 import static org.assertj.core.api.Assertions.assertThat;
+
 import org.interledger.codecs.ilp.InterledgerCodecContextFactory;
 import org.interledger.core.InterledgerAddress;
 import org.interledger.link.Link;
@@ -17,15 +18,7 @@ import org.interledger.quilt.jackson.conditions.Encoding;
 import org.interledger.stream.SendMoneyResult;
 import org.interledger.stream.StreamConnectionDetails;
 import org.interledger.stream.crypto.JavaxStreamEncryptionService;
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Optional;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.IntStream;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -48,20 +41,28 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.zalando.problem.ProblemModule;
 
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
 /**
- * Integration tests for {@link org.interledger.stream.sender.SimpleStreamSender} that connects to a running ILP Connector using the information
- * supplied in this link, and initiates a STREAM payment.
+ * Integration tests for {@link org.interledger.stream.sender.SimpleStreamSender} that connects to a running ILP
+ * Connector using the information supplied in this link, and initiates a STREAM payment.
  */
 public class SimpleStreamSenderIT {
 
+  public static final String AUTH_TOKEN = "password";
   private static final InterledgerAddress HOST_ADDRESS = InterledgerAddress.of("test.xpring-dev.rs1");
   private static final String SENDER_ACCOUNT_USERNAME = "java_stream_client";
   private static final String RECEIVER_ACCOUNT_USERNAME = "java_stream_receiver";
   private static final InterledgerAddress SENDER_ADDRESS = HOST_ADDRESS.with(SENDER_ACCOUNT_USERNAME);
   private static final InterledgerAddress RECEIVER_ADDRESS = HOST_ADDRESS.with(RECEIVER_ACCOUNT_USERNAME);
-
-  public static final String AUTH_TOKEN = "password";
-
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
   @Rule
   public GenericContainer interledgerNode = new GenericContainer<>("nhartner/interledgerrs-standalone")
       .withExposedPorts(7770)
@@ -69,9 +70,6 @@ public class SimpleStreamSenderIT {
           "--ilp_address " + HOST_ADDRESS.getValue() + " " +
           "--secret_seed 9dce76b1a20ec8d3db05ad579f3293402743767692f935a0bf06b30d2728439d " +
           "--http_bind_address 0.0.0.0:7770");
-
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
-
   private Link link;
   private StreamConnectionDetails streamConnectionDetails;
   private String interledgerNodeBaseURI;
@@ -127,7 +125,7 @@ public class SimpleStreamSenderIT {
         .build();
 
     this.link = new IlpOverHttpLink(
-        () -> Optional.of(SENDER_ADDRESS),
+        () -> SENDER_ADDRESS,
         linkSettings,
         httpClient,
         objectMapperForTesting(),

--- a/stream-parent/stream-core/pom.xml
+++ b/stream-parent/stream-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.interledger</groupId>
     <artifactId>stream-parent</artifactId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.19-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/stream-parent/stream-receiver/pom.xml
+++ b/stream-parent/stream-receiver/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>stream-parent</artifactId>
     <groupId>org.interledger</groupId>
-    <version>0.18-SNAPSHOT</version>
+    <version>0.19-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/stream-parent/stream-receiver/src/test/java/org/interledger/stream/receiver/testutils/SimulatedILPv4Network.java
+++ b/stream-parent/stream-receiver/src/test/java/org/interledger/stream/receiver/testutils/SimulatedILPv4Network.java
@@ -10,7 +10,6 @@ import org.interledger.link.LinkType;
 
 import java.math.BigDecimal;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * <p>Simulates an ILPv4 network by allowing two {@link Link} instances to speak directly to each other (as
@@ -61,7 +60,7 @@ public class SimulatedILPv4Network {
     this.leftToRightNetworkConditions = Objects.requireNonNull(leftToRightNetworkConditions);
     this.rightToLeftNetworkConditions = Objects.requireNonNull(rightToLeftNetworkConditions);
 
-    this.leftLink = new AbstractLink<LinkSettings>(() -> Optional.of(Link.SELF), LinkSettings.builder().linkType(
+    this.leftLink = new AbstractLink<LinkSettings>(() -> Link.SELF, LinkSettings.builder().linkType(
         LinkType.of("leftLink")).build()) {
       @Override
       public InterledgerResponsePacket sendPacket(final InterledgerPreparePacket preparePacket) {
@@ -70,7 +69,7 @@ public class SimulatedILPv4Network {
     };
     leftLink.setLinkId(LinkId.of("left"));
 
-    this.rightLink = new AbstractLink<LinkSettings>(() -> Optional.of(Link.SELF),
+    this.rightLink = new AbstractLink<LinkSettings>(() -> Link.SELF,
         LinkSettings.builder().linkType(LinkType.of("rightLink")).build()) {
       @Override
       public InterledgerResponsePacket sendPacket(final InterledgerPreparePacket preparePacket) {


### PR DESCRIPTION
* Fixes #259 by removing the optional operator from the ILP address supplier.
* Fix all unit tests.
* Bump SNAPSHOT version to `0.19-SNAPSHOT`

Signed-off-by: David Fuelling <sappenin@gmail.com>