### PR TITLE
Fixes #236 (Max Sequence Number)

### DIFF
--- a/stream-parent/stream-client/src/test/java/org/interledger/stream/sender/SendMoneyAggregatorTest.java
+++ b/stream-parent/stream-client/src/test/java/org/interledger/stream/sender/SendMoneyAggregatorTest.java
@@ -1,0 +1,88 @@
+package org.interledger.stream.sender;
+
+import static org.interledger.stream.StreamPacket.MAX_FRAMES_PER_CONNECTION;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import org.interledger.core.InterledgerAddress;
+import org.interledger.core.InterledgerRejectPacket;
+import org.interledger.encoding.asn.framework.CodecContext;
+import org.interledger.link.Link;
+import org.interledger.stream.crypto.StreamEncryptionService;
+import org.interledger.stream.sender.SimpleStreamSender.SendMoneyAggregator;
+
+import com.google.common.primitives.UnsignedLong;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+
+/**
+ * Unit tests for {@link SendMoneyAggregator}.
+ */
+public class SendMoneyAggregatorTest {
+
+  @Mock
+  private CodecContext streamCodecContextMock;
+  @Mock
+  private Link linkMock;
+  @Mock
+  private CongestionController congestionControllerMock;
+  @Mock
+  private StreamEncryptionService streamEncryptionServiceMock;
+
+  private byte[] sharedSecret = new byte[32];
+  private InterledgerAddress sourceAddress = InterledgerAddress.of("example.source");
+  private InterledgerAddress destinationAddress = InterledgerAddress.of("example.destination");
+  private UnsignedLong originalAmountToSend = UnsignedLong.valueOf(10L);
+
+  private SendMoneyAggregator sendMoneyAggregator;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    when(congestionControllerMock.getMaxAmount()).thenReturn(UnsignedLong.ONE);
+    when(streamEncryptionServiceMock.encrypt(any(), any())).thenReturn(new byte[32]);
+    when(streamEncryptionServiceMock.decrypt(any(), any())).thenReturn(new byte[32]);
+    when(linkMock.sendPacket(any())).thenReturn(mock(InterledgerRejectPacket.class));
+
+    this.sendMoneyAggregator = new SendMoneyAggregator(
+        Executors.newFixedThreadPool(1), streamCodecContextMock, linkMock, congestionControllerMock,
+        streamEncryptionServiceMock, sharedSecret, sourceAddress, destinationAddress, originalAmountToSend
+    );
+  }
+
+  @Test
+  public void sendMoneyWithMaxSequenceMinus1() throws ExecutionException, InterruptedException {
+    sendMoneyAggregator.setSequenceForTesting(MAX_FRAMES_PER_CONNECTION.minus(UnsignedLong.ONE));
+    sendMoneyAggregator.send().get();
+
+    // Expect 1 Link call for the OpenConnection, and 1 Link call for the CloseConnection
+    Mockito.verify(linkMock, times(2)).sendPacket(any());
+  }
+
+  @Test
+  public void sendMoneyWithMaxSequence() throws ExecutionException, InterruptedException {
+    sendMoneyAggregator.setSequenceForTesting(MAX_FRAMES_PER_CONNECTION);
+    sendMoneyAggregator.send().get();
+
+    // Expect 1 Link call for the CloseConnection
+    Mockito.verify(linkMock).sendPacket(any());
+  }
+
+  @Test
+  public void sendMoneyWithMaxSequencePlus1() throws ExecutionException, InterruptedException {
+    sendMoneyAggregator.setSequenceForTesting(MAX_FRAMES_PER_CONNECTION.plus(UnsignedLong.ONE));
+    sendMoneyAggregator.send().get();
+
+    // Expect 1 Link call for the CloseConnection
+    Mockito.verify(linkMock).sendPacket(any());
+  }
+}

--- a/stream-parent/stream-client/src/test/java/org/interledger/stream/sender/SimpleStreamSenderTests.java
+++ b/stream-parent/stream-client/src/test/java/org/interledger/stream/sender/SimpleStreamSenderTests.java
@@ -1,0 +1,68 @@
+package org.interledger.stream.sender;
+
+import static org.mockito.Mockito.mock;
+
+import org.interledger.link.Link;
+import org.interledger.stream.crypto.StreamEncryptionService;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Unit tests for {@link SimpleStreamSenderTests}.
+ */
+public class SimpleStreamSenderTests {
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Mock
+  private StreamEncryptionService streamEncryptionServiceMock;
+
+  @Mock
+  private Link linkMock;
+
+  private SimpleStreamSender simpleStreamSender;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    simpleStreamSender = new SimpleStreamSender(streamEncryptionServiceMock, linkMock);
+  }
+
+  @Test
+  public void constructWithNullEncryptionService() {
+    expectedException.expect(NullPointerException.class);
+    new SimpleStreamSender(null, linkMock);
+  }
+
+  @Test
+  public void constructWithNullLink() {
+    expectedException.expect(NullPointerException.class);
+    new SimpleStreamSender(streamEncryptionServiceMock, null);
+  }
+
+  @Test
+  public void constructThreeArgWithNullEncryptionService() {
+    expectedException.expect(NullPointerException.class);
+    new SimpleStreamSender(null, linkMock, mock(ExecutorService.class));
+  }
+
+  @Test
+  public void constructThreeArgWithNullLink() {
+    expectedException.expect(NullPointerException.class);
+    new SimpleStreamSender(streamEncryptionServiceMock, null, mock(ExecutorService.class));
+  }
+
+  @Test
+  public void constructThreeArgWithNullExecutor() {
+    expectedException.expect(NullPointerException.class);
+    new SimpleStreamSender(streamEncryptionServiceMock, linkMock, null);
+  }
+}

--- a/stream-parent/stream-core/src/main/java/org/interledger/stream/StreamUtils.java
+++ b/stream-parent/stream-core/src/main/java/org/interledger/stream/StreamUtils.java
@@ -7,7 +7,6 @@ import org.interledger.stream.crypto.Random;
 import com.google.common.hash.Hashing;
 import com.google.common.primitives.UnsignedLong;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 

--- a/stream-parent/stream-core/src/test/java/org/interledger/stream/StreamPacketTest.java
+++ b/stream-parent/stream-core/src/test/java/org/interledger/stream/StreamPacketTest.java
@@ -1,11 +1,12 @@
 package org.interledger.stream;
 
-import com.google.common.primitives.UnsignedLong;
-import org.interledger.core.InterledgerPacketType;
-import org.junit.Test;
-
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.Mockito.spy;
+
+import org.interledger.core.InterledgerPacketType;
+
+import com.google.common.primitives.UnsignedLong;
+import org.junit.Test;
 
 public class StreamPacketTest {
 
@@ -19,5 +20,23 @@ public class StreamPacketTest {
     assertThat(packet.version()).isEqualTo((short) 1);
     // make sure interface default method is exercised
     assertThat(spy(StreamPacket.class).version()).isEqualTo((short) 1);
+  }
+
+  @Test
+  public void testSafeSequence() {
+    final StreamPacketBuilder builder = StreamPacket.builder()
+        .interledgerPacketType(InterledgerPacketType.PREPARE)
+        .sequence(UnsignedLong.ZERO)
+        .prepareAmount(UnsignedLong.ZERO);
+
+    assertThat(builder.sequence(UnsignedLong.ZERO).build().sequenceIsSafeForSingleSharedSecret()).isTrue();
+    assertThat(builder.sequence(UnsignedLong.ONE).build().sequenceIsSafeForSingleSharedSecret()).isTrue();
+    assertThat(builder.sequence(StreamPacket.MAX_FRAMES_PER_CONNECTION.minus(UnsignedLong.ONE)).build()
+        .sequenceIsSafeForSingleSharedSecret()).isTrue();
+    assertThat(builder.sequence(StreamPacket.MAX_FRAMES_PER_CONNECTION).build().sequenceIsSafeForSingleSharedSecret())
+        .isFalse();
+    assertThat(builder.sequence(StreamPacket.MAX_FRAMES_PER_CONNECTION.plus(UnsignedLong.ONE)).build()
+        .sequenceIsSafeForSingleSharedSecret()).isFalse();
+    assertThat(builder.sequence(UnsignedLong.MAX_VALUE).build().sequenceIsSafeForSingleSharedSecret()).isFalse();
   }
 }


### PR DESCRIPTION
* Per IL-RFC-29, ensure that the number of StreamPackets does not exceed 2^31.
* Add unit test coverage to STREAM sender and receiver.
* Enhance StreamPacket to allow easily computing this condition.

Signed-off-by: David Fuelling <sappenin@gmail.com>