### PR TITLE
fix bug with sendMoney between accounts in different assets

### DIFF
--- a/examples/send-money/pom.xml
+++ b/examples/send-money/pom.xml
@@ -62,6 +62,11 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/examples/send-money/src/main/java/org/interledger/examples/SendMoneyExample.java
+++ b/examples/send-money/src/main/java/org/interledger/examples/SendMoneyExample.java
@@ -15,6 +15,7 @@ import org.interledger.spsp.client.rust.InterledgerRustNodeClient;
 import org.interledger.stream.SendMoneyResult;
 import org.interledger.core.SharedSecret;
 import org.interledger.stream.sender.SimpleStreamSender;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -35,11 +36,9 @@ public class SendMoneyExample {
   // NOTE - replace this with the passkey for your sender account
   private static final String SENDER_PASS_KEY = "jxelaxvqz2ne6";
   // NOTE - replace this with the payment pointer for your receiver account
-  private static final String RECEIVER_PAYMENT_POINTER = "$rs3.xpring.dev/accounts/user_jwmqq7kv/spsp";
+  private static final String RECEIVER_PAYMENT_POINTER = "$rs3.xpring.dev/accounts/user_uk152ktl/spsp";
 
   private static final String TESTNET_URI = "https://rs3.xpring.dev";
-
-  private static final int ASSET_SCALE = 9;
 
   private static final InterledgerAddress SENDER_ADDRESS =
       InterledgerAddress.of("test.xpring-dev.rs3").with(SENDER_ACCOUNT_USERNAME);
@@ -63,7 +62,7 @@ public class SendMoneyExample {
 
     // Send payment using STREAM
     SendMoneyResult result = simpleStreamSender.sendMoney(SharedSecret.of(connectionDetails.sharedSecret().value()),
-        SENDER_ADDRESS, connectionDetails.destinationAddress(), UnsignedLong.valueOf(1000))
+        SENDER_ADDRESS, connectionDetails.destinationAddress(), UnsignedLong.valueOf(100000), Duration.ofMillis(30000))
         .get();
 
     System.out.println("Send money result: " + result);

--- a/stream-parent/stream-client/src/test/java/org/interledger/stream/sender/SendMoneyAggregatorTest.java
+++ b/stream-parent/stream-client/src/test/java/org/interledger/stream/sender/SendMoneyAggregatorTest.java
@@ -195,9 +195,9 @@ public class SendMoneyAggregatorTest {
     when(congestionControllerMock.hasInFlight()).thenReturn(moneyInFlight);
     when(streamConnectionMock.isClosed()).thenReturn(streamConnectionClosed);
     if (moreToSend) {
-      sendMoneyAggregator.setDeliveredAmountForTesting(UnsignedLong.ZERO);
+      sendMoneyAggregator.setAmountSentForTesting(UnsignedLong.ZERO);
     } else {
-      sendMoneyAggregator.setDeliveredAmountForTesting(UnsignedLong.valueOf(10L));
+      sendMoneyAggregator.setAmountSentForTesting(UnsignedLong.valueOf(10L));
     }
   }
 }

--- a/stream-parent/stream-core/src/main/java/org/interledger/stream/SendMoneyResult.java
+++ b/stream-parent/stream-core/src/main/java/org/interledger/stream/SendMoneyResult.java
@@ -25,11 +25,29 @@ public interface SendMoneyResult {
   UnsignedLong originalAmount();
 
   /**
-   * The actual amount, in the senders units, that was delivered to the receiver.
+   * The actual amount, in the receivers units, that was delivered to the receiver. Any currency conversion and/or
+   * connector fees may cause this to be different than the amount sent.
    *
    * @return An {@link UnsignedLong} representing the amount delivered.
    */
   UnsignedLong amountDelivered();
+
+  /**
+   * The actual amount, in the senders units, that was sent to the receiver. In the case, of a timeout or rejected
+   * packets this amount may be less than the requested amount to be sent.
+   *
+   * @return An {@link UnsignedLong} representing the amount sent.
+   */
+  UnsignedLong amountSent();
+
+  /**
+   * The actual amount, in the senders units, that is still left to send. If the payment was successful, this amount
+   * will be 0. If there was an issue sending payment (repeated rejections or timeouts), this will be the amount that
+   * could not be sent or which may have been sent but we failed to receive the fulfillment packet (network issue).
+   *
+   * @return An {@link UnsignedLong} representing the amount left to send.
+   */
+  UnsignedLong amountLeftToSend();
 
   /**
    * Metadata representing the number of fulfilled packets in a request to send money. Note that STREAM implementations
@@ -70,6 +88,6 @@ public interface SendMoneyResult {
    */
   @Value.Derived
   default boolean successfulPayment() {
-    return amountDelivered().equals(originalAmount());
+    return amountSent().equals(originalAmount());
   }
 }

--- a/stream-parent/stream-core/src/test/java/org/interledger/stream/SendMoneyResultTest.java
+++ b/stream-parent/stream-core/src/test/java/org/interledger/stream/SendMoneyResultTest.java
@@ -17,6 +17,8 @@ public class SendMoneyResultTest {
     SendMoneyResult result = SendMoneyResult.builder()
         .originalAmount(UnsignedLong.ZERO)
         .amountDelivered(UnsignedLong.ZERO)
+        .amountSent(UnsignedLong.ZERO)
+        .amountLeftToSend(UnsignedLong.ZERO)
         .numFulfilledPackets(10)
         .numRejectPackets(5)
         .sendMoneyDuration(Duration.ZERO)


### PR DESCRIPTION
track how much money was sent from the sender's perspective instead of receiver's
fix issue with ScheduledThreadPoolExecutor not getting shutdown

Signed-off-by: nhartner <nhartner@gmail.com>