### PR TITLE
Fixes #341 (Make Quilt work on Android)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,4 +69,50 @@ jobs:
       # publish the coverage report to codecov.io
       - run: bash <(curl -s https://codecov.io/bash)
 
+  android_build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/openjdk:8-jdk
 
+    working_directory: ~/repo
+
+    environment:
+      # Customize the JVM maximum heap limit
+      MAVEN_OPTS: -Xmx3200m
+      JAVA_HOME: /usr/lib/jvm/jdk1.8.0/
+
+    steps:
+
+      # apply the JCE unlimited strength policy to allow the PSK 256 bit key length
+      # solution from http://qiita.com/yoskhdia/items/f4702a3abc4467de69b0
+      - run:
+          name: Getting JCE unlimited strength policy to allow the 256 bit keys
+          command: |
+            curl -L --cookie 'oraclelicense=accept-securebackup-cookie;'  http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip -o /tmp/jce_policy.zip
+            unzip -o /tmp/jce_policy.zip -d /tmp
+            sudo mv -f /tmp/UnlimitedJCEPolicyJDK8/US_export_policy.jar $JAVA_HOME/jre/lib/security/US_export_policy.jar
+            sudo mv -f /tmp/UnlimitedJCEPolicyJDK8/local_policy.jar $JAVA_HOME/jre/lib/security/local_policy.jar
+
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "pom.xml" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run:
+          name: Maven Install
+          command:  mvn dependency:go-offline install -Pandroid
+
+workflows:
+  version: 2
+
+  # In CircleCI v2.1, when no workflow is provided in config, an implicit one is used. However, if you declare a
+  #  workflow to run a scheduled build, the implicit workflow is no longer run. You must add the job workflow to your
+  # config in order for CircleCI to also build on every commit.
+  commit:
+    jobs:
+      - build
+      - build_android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
       # publish the coverage report to codecov.io
       - run: bash <(curl -s https://codecov.io/bash)
 
-  android_build:
+  build_android:
     docker:
       # specify the version you desire here
       - image: circleci/openjdk:8-jdk

--- a/ilp-core/pom.xml
+++ b/ilp-core/pom.xml
@@ -20,6 +20,7 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/link-parent/link-ilp-over-http/src/test/java/org/interledger/link/http/auth/JwtHs256BearerTokenSupplierTest.java
+++ b/link-parent/link-ilp-over-http/src/test/java/org/interledger/link/http/auth/JwtHs256BearerTokenSupplierTest.java
@@ -1,6 +1,5 @@
 package org.interledger.link.http.auth;
 
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -9,7 +8,10 @@ import org.interledger.link.http.IlpOverHttpLinkSettings;
 import org.interledger.link.http.OutgoingLinkSettings;
 
 import okhttp3.HttpUrl;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 import java.time.Duration;
 
@@ -18,23 +20,37 @@ import java.time.Duration;
  */
 public class JwtHs256BearerTokenSupplierTest {
 
+  private static final byte[] EMPTY_BYTES = new byte[32];
+
+  @Mock
+  private SharedSecretBytesSupplier secretBytesSupplier;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    when(secretBytesSupplier.get()).thenReturn(EMPTY_BYTES);
+  }
+
   @Test
   public void checkCaching() {
-    SharedSecretBytesSupplier secretBytesSupplier = mock(SharedSecretBytesSupplier.class);
-    byte[] muhBytes = new byte[32];
-    when(secretBytesSupplier.get()).thenReturn(muhBytes);
-    OutgoingLinkSettings linkSettings = createOutgoingSettings(Duration.ofSeconds(5));
+    OutgoingLinkSettings linkSettings = createOutgoingSettings(Duration.ofMinutes(5));
     JwtHs256BearerTokenSupplier tokenSupplier = new JwtHs256BearerTokenSupplier(secretBytesSupplier, linkSettings);
     tokenSupplier.get();
     tokenSupplier.get();
-    verify(secretBytesSupplier, times(1)).get();
+    verify(secretBytesSupplier).get();
+  }
+
+  @Test
+  public void checkCachingWithCachingDisabled() {
+    OutgoingLinkSettings linkSettings = createOutgoingSettings(Duration.ofMinutes(0));
+    JwtHs256BearerTokenSupplier tokenSupplier = new JwtHs256BearerTokenSupplier(secretBytesSupplier, linkSettings);
+    tokenSupplier.get();
+    tokenSupplier.get();
+    verify(secretBytesSupplier, times(2)).get();
   }
 
   @Test
   public void checkCacheExpiry() throws Exception {
-    SharedSecretBytesSupplier secretBytesSupplier = mock(SharedSecretBytesSupplier.class);
-    byte[] muhBytes = new byte[32];
-    when(secretBytesSupplier.get()).thenReturn(muhBytes);
     OutgoingLinkSettings linkSettings = createOutgoingSettings(Duration.ofMillis(2));
     JwtHs256BearerTokenSupplier tokenSupplier = new JwtHs256BearerTokenSupplier(secretBytesSupplier, linkSettings);
     tokenSupplier.get();

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,15 @@
     <name>Hyperledger and its contributors</name>
   </organization>
 
-  <!-- Signing profile for signed distributions -->
   <profiles>
+    <!-- Specify android-compatible dependencies -->
+    <profile>
+      <id>android</id>
+      <properties>
+        <guava.version>28.1-android</guava.version>
+      </properties>
+    </profile>
+    <!-- Signing profile for signed distributions -->
     <profile>
       <id>release</id>
       <build>
@@ -92,9 +99,11 @@
     <checkstyle.config.location>checkstyle.xml</checkstyle.config.location>
     <checkstyle.violationSeverity>error</checkstyle.violationSeverity>
 
+    <guava.version>28.1-jre</guava.version>
     <jackson.version>2.10.0.pr3</jackson.version>
     <okhttp.version>4.2.0</okhttp.version>
     <slf4j.version>1.7.28</slf4j.version>
+
     <skipITs>false</skipITs>
   </properties>
 
@@ -254,7 +263,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>28.1-jre</version>
+        <version>${guava.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.annotation</groupId>


### PR DESCRIPTION
* Use android-compatible API for token expiry.
* Update build file to easily support building for both JRE and Android platforms.

Signed-off-by: David Fuelling <sappenin@gmail.com>