### PR TITLE
Fix LGTM Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Hyperledger Quilt [![Discuss][forum-image]][forum-url] [![twitter][twitter-image]][twitter-url]
-[![circle-ci][circle-image]][circle-url] [![codecov][codecov-image]][codecov-url] [![codacy][codacy-image]][codacy-url] [![issues][github-issues-image]][github-issues-url]
+[![circle-ci][circle-image]][circle-url] 
+[![codecov][codecov-image]][codecov-url] 
+[![lgtm-cq][lgtm-cq-image]][lgtm-cq-url] 
+[![lgtm-alerts][lgtm-alerts-image]][lgtm-alerts-url]
+[![issues][github-issues-image]][github-issues-url]
 
 Quilt is a Java implementation of the [Interledger](https://interledger.org) protocol. 
 
@@ -214,6 +218,10 @@ $ mvn checkstyle:checkstyle
 [codecov-url]: https://codecov.io/gh/hyperledger/quilt
 [codacy-image]: https://api.codacy.com/project/badge/Grade/875a1b0b076a4a7399fa43d0c6f27748
 [codacy-url]: https://www.codacy.com/manual/xpring/quilt?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=hyperledger/quilt&amp;utm_campaign=Badge_Grade
+[lgtm-cq-image]: https://img.shields.io/lgtm/grade/java/g/hyperledger/quilt.svg?logo=lgtm&logoWidth=18
+[lgtm-cq-url]: https://lgtm.com/projects/g/hyperledger/quilt/context:java
+[lgtm-alerts-image]: https://img.shields.io/lgtm/alerts/g/hyperledger/quilt.svg?logo=lgtm&logoWidth=18
+[lgtm-alerts-url]: https://lgtm.com/projects/g/hyperledger/quilt/alerts/
 [twitter-image]: https://img.shields.io/twitter/follow/interledger.svg?style=social
 [twitter-url]: https://twitter.com/intent/follow?screen_name=interledger
 [github-issues-image]: https://img.shields.io/github/issues/hyperledger/quilt.svg


### PR DESCRIPTION
Moving to LGTM because it provides security audit coverage and it's unclear if codacy does that.

Signed-off-by: David Fuelling <sappenin@gmail.com>