### PR TITLE
Add link Jackson serializers and Fix #362

### DIFF
--- a/ilp-core/src/main/java/org/interledger/core/InterledgerAddress.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerAddress.java
@@ -205,6 +205,7 @@ public interface InterledgerAddress {
     AllocationScheme TEST1 = AllocationScheme.of("test1");
     AllocationScheme TEST2 = AllocationScheme.of("test2");
     AllocationScheme TEST3 = AllocationScheme.of("test3");
+    AllocationScheme LOCAL = AllocationScheme.of("local");
 
     /**
      * Constructor to allow quick construction from a {@link String} representation of an ILP address allocation
@@ -263,7 +264,7 @@ public interface InterledgerAddress {
         defaults = @Value.Immutable(intern = true))
     abstract class AbstractAllocationScheme implements AllocationScheme {
 
-      private static final String SCHEME_REGEX = "(g|private|example|peer|self|test[1-3]?)$";
+      private static final String SCHEME_REGEX = "(g|private|example|peer|self|test[1-3]?|local)$";
       private static final Pattern SCHEME_PREFIX_ONLY_PATTERN = Pattern.compile(SCHEME_REGEX);
 
       /**
@@ -315,7 +316,7 @@ public interface InterledgerAddress {
 
     static final String SEPARATOR_REGEX = "[.]";
 
-    private static final String SCHEME_REGEX = "(g|private|example|peer|self|test[1-3]?)";
+    private static final String SCHEME_REGEX = "(g|private|example|peer|self|test[1-3]?|local)";
     static final Pattern SCHEME_PATTERN = Pattern.compile(SCHEME_REGEX);
 
     private static final String VALID_ADDRESS_REGEX

--- a/ilp-core/src/main/java/org/interledger/core/InterledgerAddressPrefix.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerAddressPrefix.java
@@ -54,6 +54,7 @@ public interface InterledgerAddressPrefix {
   InterledgerAddressPrefix TEST1 = InterledgerAddressPrefix.from(AllocationScheme.TEST1);
   InterledgerAddressPrefix TEST2 = InterledgerAddressPrefix.from(AllocationScheme.TEST2);
   InterledgerAddressPrefix TEST3 = InterledgerAddressPrefix.from(AllocationScheme.TEST3);
+  InterledgerAddressPrefix LOCAL = InterledgerAddressPrefix.from(AllocationScheme.LOCAL);
 
   /**
    * Constructor to allow quick construction from a {@link String}.

--- a/ilp-core/src/test/java/org/interledger/core/AllocationSchemeTest.java
+++ b/ilp-core/src/test/java/org/interledger/core/AllocationSchemeTest.java
@@ -1,0 +1,131 @@
+package org.interledger.core;
+
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.interledger.core.InterledgerAddress.AbstractInterledgerAddress.Error.ILLEGAL_ENDING;
+
+import org.interledger.core.InterledgerAddress.AllocationScheme;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class AllocationSchemeTest {
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void ofWithInvalidScheme() {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("The 'foo' AllocationScheme is invalid!");
+    AllocationScheme.of("foo");
+  }
+
+  @Test
+  public void ofWithInvalidButSimilarScheme() {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("The 'local1' AllocationScheme is invalid!");
+    AllocationScheme.of("local1");
+  }
+
+  @Test
+  public void of() {
+    assertThat(AllocationScheme.of("g")).isEqualTo(AllocationScheme.GLOBAL);
+    assertThat(AllocationScheme.of("private")).isEqualTo(AllocationScheme.PRIVATE);
+    assertThat(AllocationScheme.of("example")).isEqualTo(AllocationScheme.EXAMPLE);
+    assertThat(AllocationScheme.of("peer")).isEqualTo(AllocationScheme.PEER);
+    assertThat(AllocationScheme.of("self")).isEqualTo(AllocationScheme.SELF);
+    assertThat(AllocationScheme.of("test")).isEqualTo(AllocationScheme.TEST);
+    assertThat(AllocationScheme.of("test1")).isEqualTo(AllocationScheme.TEST1);
+    assertThat(AllocationScheme.of("test2")).isEqualTo(AllocationScheme.TEST2);
+    assertThat(AllocationScheme.of("test3")).isEqualTo(AllocationScheme.TEST3);
+    assertThat(AllocationScheme.of("local")).isEqualTo(AllocationScheme.LOCAL);
+  }
+
+  @Test
+  public void getValue() {
+    assertThat(AllocationScheme.of("g").getValue()).isEqualTo("g");
+    assertThat(AllocationScheme.of("private").getValue()).isEqualTo("private");
+    assertThat(AllocationScheme.of("example").getValue()).isEqualTo("example");
+    assertThat(AllocationScheme.of("peer").getValue()).isEqualTo("peer");
+    assertThat(AllocationScheme.of("self").getValue()).isEqualTo("self");
+    assertThat(AllocationScheme.of("test").getValue()).isEqualTo("test");
+    assertThat(AllocationScheme.of("test1").getValue()).isEqualTo("test1");
+    assertThat(AllocationScheme.of("test2").getValue()).isEqualTo("test2");
+    assertThat(AllocationScheme.of("test3").getValue()).isEqualTo("test3");
+    assertThat(AllocationScheme.of("local").getValue()).isEqualTo("local");
+  }
+
+  @Test
+  public void testInterledgerAddressCreationWithCorrectAllocationScheme() {
+    InterledgerAddress globalAddress = AllocationScheme.GLOBAL.with("bob.baz");
+    Assertions.assertThat(globalAddress.getAllocationScheme()).isEqualTo(AllocationScheme.GLOBAL);
+    Assertions.assertThat(globalAddress.getValue()).isEqualTo("g.bob.baz");
+
+    InterledgerAddress exampleAddress = AllocationScheme.EXAMPLE.with("bob.baz");
+    Assertions.assertThat(exampleAddress.getAllocationScheme()).isEqualTo(AllocationScheme.EXAMPLE);
+    Assertions.assertThat(exampleAddress.getValue()).isEqualTo("example.bob.baz");
+
+    InterledgerAddress privateAddress = AllocationScheme.PRIVATE.with("bob.baz");
+    Assertions.assertThat(privateAddress.getAllocationScheme()).isEqualTo(AllocationScheme.PRIVATE);
+    Assertions.assertThat(privateAddress.getValue()).isEqualTo("private.bob.baz");
+
+    InterledgerAddress peerAddress = AllocationScheme.PEER.with("bob.baz");
+    Assertions.assertThat(peerAddress.getAllocationScheme()).isEqualTo(AllocationScheme.PEER);
+    Assertions.assertThat(peerAddress.getValue()).isEqualTo("peer.bob.baz");
+
+    InterledgerAddress selfAddress = AllocationScheme.SELF.with("bob.baz");
+    Assertions.assertThat(selfAddress.getAllocationScheme()).isEqualTo(AllocationScheme.SELF);
+    Assertions.assertThat(selfAddress.getValue()).isEqualTo("self.bob.baz");
+
+    InterledgerAddress testAddress = AllocationScheme.TEST.with("bob.baz");
+    Assertions.assertThat(testAddress.getAllocationScheme()).isEqualTo(AllocationScheme.TEST);
+    Assertions.assertThat(testAddress.getValue()).isEqualTo("test.bob.baz");
+
+    InterledgerAddress test1Address = AllocationScheme.TEST1.with("bob.baz");
+    Assertions.assertThat(test1Address.getAllocationScheme()).isEqualTo(AllocationScheme.TEST1);
+    Assertions.assertThat(test1Address.getValue()).isEqualTo("test1.bob.baz");
+
+    InterledgerAddress test2Address = AllocationScheme.TEST2.with("bob.baz");
+    Assertions.assertThat(test2Address.getAllocationScheme()).isEqualTo(AllocationScheme.TEST2);
+    Assertions.assertThat(test2Address.getValue()).isEqualTo("test2.bob.baz");
+
+    InterledgerAddress test3Address = AllocationScheme.TEST3.with("bob.baz");
+    Assertions.assertThat(test3Address.getAllocationScheme()).isEqualTo(AllocationScheme.TEST3);
+    Assertions.assertThat(test3Address.getValue()).isEqualTo("test3.bob.baz");
+
+    InterledgerAddress localAddress = AllocationScheme.LOCAL.with("bob.baz");
+    Assertions.assertThat(localAddress.getAllocationScheme()).isEqualTo(AllocationScheme.LOCAL);
+    Assertions.assertThat(localAddress.getValue()).isEqualTo("local.bob.baz");
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testInterledgerAddressCreationWithNull() {
+    try {
+      AllocationScheme.GLOBAL.with(null);
+      fail("should have failed and the error been caught");
+    } catch (NullPointerException e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo("value must not be null!");
+      throw e;
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInterledgerAddressCreationWithEmpty() {
+    try {
+      AllocationScheme.GLOBAL.with("");
+      fail("should have failed and the error been caught");
+    } catch (IllegalArgumentException e) {
+      Assertions.assertThat(e.getMessage()).isEqualTo(ILLEGAL_ENDING.getMessageFormat());
+      throw e;
+    }
+  }
+
+  @Test
+  public void testAllocationScheme() {
+    Assertions.assertThat(InterledgerAddress.of("g.foo.bob").getAllocationScheme())
+        .isEqualTo(AllocationScheme.builder().value("g").build());
+  }
+}

--- a/ilp-core/src/test/java/org/interledger/core/InterledgerAddressPrefixTest.java
+++ b/ilp-core/src/test/java/org/interledger/core/InterledgerAddressPrefixTest.java
@@ -9,9 +9,9 @@ package org.interledger.core;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -271,8 +271,7 @@ public class InterledgerAddressPrefixTest {
   }
 
   /**
-   * Validates adding a destination address (as an InterledgerAddressPrefix) to a destination
-   * address.
+   * Validates adding a destination address (as an InterledgerAddressPrefix) to a destination address.
    */
   @Test
   public void testDestinationAddressWithDestinationAddress() {
@@ -355,6 +354,7 @@ public class InterledgerAddressPrefixTest {
     assertThat(InterledgerAddressPrefix.of("test1.1.1").hasPrefix()).isTrue();
     assertThat(InterledgerAddressPrefix.of("test2.1.1").hasPrefix()).isTrue();
     assertThat(InterledgerAddressPrefix.of("test3.1.1").hasPrefix()).isTrue();
+    assertThat(InterledgerAddressPrefix.of("local.1.1").hasPrefix()).isTrue();
   }
 
   @Test
@@ -392,114 +392,92 @@ public class InterledgerAddressPrefixTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSchemePrefix_02() {
-    assertValidationErrorThenThrow(".self",
-        INVALID_SCHEME_PREFIX);
+    assertValidationErrorThenThrow(".self", INVALID_SCHEME_PREFIX);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSchemePrefix_04() {
-    assertValidationErrorThenThrow(".foo",
-        INVALID_SCHEME_PREFIX);
+    assertValidationErrorThenThrow(".foo", INVALID_SCHEME_PREFIX);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSchemePrefix_05() {
-    assertValidationErrorThenThrow("gg",
-        INVALID_SCHEME_PREFIX,
-        "gg");
+    assertValidationErrorThenThrow("gg", INVALID_SCHEME_PREFIX, "gg");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSchemePrefix_06() {
-    assertValidationErrorThenThrow(" g",
-        INVALID_SCHEME_PREFIX,
-        " g");
+    assertValidationErrorThenThrow(" g", INVALID_SCHEME_PREFIX, " g");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSchemePrefix_07() {
-    assertValidationErrorThenThrow("g ",
-        INVALID_SCHEME_PREFIX,
-        "g ");
+    assertValidationErrorThenThrow("g ", INVALID_SCHEME_PREFIX, "g ");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSchemePrefix_08() {
-    assertValidationErrorThenThrow("@@@",
-        INVALID_SCHEME_PREFIX,
-        "@@@");
+    assertValidationErrorThenThrow("@@@", INVALID_SCHEME_PREFIX, "@@@");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSegment_01() {
-    assertValidationErrorThenThrow("g.@@@",
-        INVALID_SEGMENT, "@@@");
+    assertValidationErrorThenThrow("g.@@@", INVALID_SEGMENT, "@@@");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSegment_02() {
-    assertValidationErrorThenThrow("g. ",
-        INVALID_SEGMENT, " ");
+    assertValidationErrorThenThrow("g. ", INVALID_SEGMENT, " ");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSegment_03() {
-    assertValidationErrorThenThrow("g.é",
-        INVALID_SEGMENT, "é");
+    assertValidationErrorThenThrow("g.é", INVALID_SEGMENT, "é");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSegment_04() {
-    assertValidationErrorThenThrow("g.", ILLEGAL_ENDING,
-        "");
+    assertValidationErrorThenThrow("g.", ILLEGAL_ENDING, "");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSegment_04b() {
-    assertValidationErrorThenThrow("g.foo.",
-        ILLEGAL_ENDING, "");
+    assertValidationErrorThenThrow("g.foo.", ILLEGAL_ENDING, "");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSegment_05() {
-    assertValidationErrorThenThrow("g..bar",
-        INVALID_SEGMENT, "");
+    assertValidationErrorThenThrow("g..bar", INVALID_SEGMENT, "");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSegment_06() {
-    assertValidationErrorThenThrow("g.foo.@.baz",
-        INVALID_SEGMENT, "@");
+    assertValidationErrorThenThrow("g.foo.@.baz", INVALID_SEGMENT, "@");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSegment_07() {
-    assertValidationErrorThenThrow("g.foo.bar.a@1",
-        INVALID_SEGMENT, "a@1");
+    assertValidationErrorThenThrow("g.foo.bar.a@1", INVALID_SEGMENT, "a@1");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSegment_08() {
-    assertValidationErrorThenThrow("g.foo.bar.baz ",
-        INVALID_SEGMENT, "baz ");
+    assertValidationErrorThenThrow("g.foo.bar.baz ", INVALID_SEGMENT, "baz ");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithInvalidSegment_09() {
-    assertValidationErrorThenThrow("g.foo.bar.baz\r\n",
-        INVALID_SEGMENT, "baz\r\n");
+    assertValidationErrorThenThrow("g.foo.bar.baz\r\n", INVALID_SEGMENT, "baz\r\n");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithSegmentsUnderflow() {
-    assertValidationErrorThenThrow("",
-        INVALID_SCHEME_PREFIX);
+    assertValidationErrorThenThrow("", INVALID_SCHEME_PREFIX);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidateWithLengthOverflow() {
-    assertValidationErrorThenThrow(TOO_LONG,
-        ADDRESS_OVERFLOW);
+    assertValidationErrorThenThrow(TOO_LONG, ADDRESS_OVERFLOW);
   }
 
   private void assertValidationErrorThenThrow(final String actualAddressString,
@@ -546,8 +524,7 @@ public class InterledgerAddressPrefixTest {
 
   @Test
   public void testFromAddressWithAddress() {
-    final InterledgerAddressPrefix prefix = InterledgerAddressPrefix
-        .from(InterledgerAddress.of(G_FOO));
+    final InterledgerAddressPrefix prefix = InterledgerAddressPrefix.from(InterledgerAddress.of(G_FOO));
     assertThat(prefix.getValue()).isEqualTo(G_FOO);
   }
 
@@ -567,8 +544,7 @@ public class InterledgerAddressPrefixTest {
 
   @Test
   public void testFromAddressWithAllocationScheme() {
-    final InterledgerAddressPrefix allocationScheme = InterledgerAddressPrefix
-        .from(AllocationScheme.GLOBAL);
+    final InterledgerAddressPrefix allocationScheme = InterledgerAddressPrefix.from(AllocationScheme.GLOBAL);
     assertThat(allocationScheme).isEqualTo(InterledgerAddressPrefix.GLOBAL);
   }
 
@@ -583,5 +559,6 @@ public class InterledgerAddressPrefixTest {
     assertThat(InterledgerAddressPrefix.from(AllocationScheme.TEST1)).isEqualTo(InterledgerAddressPrefix.TEST1);
     assertThat(InterledgerAddressPrefix.from(AllocationScheme.TEST2)).isEqualTo(InterledgerAddressPrefix.TEST2);
     assertThat(InterledgerAddressPrefix.from(AllocationScheme.TEST3)).isEqualTo(InterledgerAddressPrefix.TEST3);
+    assertThat(InterledgerAddressPrefix.from(AllocationScheme.LOCAL)).isEqualTo(InterledgerAddressPrefix.LOCAL);
   }
 }

--- a/ilp-core/src/test/java/org/interledger/core/InterledgerAddressSchemeTest.java
+++ b/ilp-core/src/test/java/org/interledger/core/InterledgerAddressSchemeTest.java
@@ -53,7 +53,7 @@ public class InterledgerAddressSchemeTest {
   @Parameters(name = "{index}: allocationScheme({0})")
   public static Iterable<Object[]> schemes() {
     return Arrays.asList(new Object[][] {
-        {"g"}, {"private"}, {"example"}, {"peer"}, {"self"}, {"test1"}, {"test2"}, {"test3"}
+        {"g"}, {"private"}, {"example"}, {"peer"}, {"self"}, {"test1"}, {"test2"}, {"test3"}, {"local"}
     });
   }
 

--- a/ilp-core/src/test/java/org/interledger/core/InterledgerAddressTest.java
+++ b/ilp-core/src/test/java/org/interledger/core/InterledgerAddressTest.java
@@ -160,12 +160,6 @@ public class InterledgerAddressTest {
     assertThat(InterledgerAddress.of("g.foo.bob").getValue()).isEqualTo("g.foo.bob");
   }
 
-  @Test
-  public void testAllocationScheme() {
-    assertThat(InterledgerAddress.of("g.foo.bob").getAllocationScheme())
-        .isEqualTo(AllocationScheme.builder().value("g").build());
-  }
-
   @Test(expected = NullPointerException.class)
   public void testOfWithNull() {
     try {
@@ -354,68 +348,6 @@ public class InterledgerAddressTest {
   }
 
   @Test
-  public void testInterledgerAddressCreationWithCorrectAllocationScheme() {
-    InterledgerAddress globalAddress = AllocationScheme.GLOBAL.with("bob.baz");
-    InterledgerAddress exampleAddress = AllocationScheme.EXAMPLE.with("bob.baz");
-    InterledgerAddress peerAddress = AllocationScheme.PEER.with("bob.baz");
-    InterledgerAddress privateAddress = AllocationScheme.PRIVATE.with("bob.baz");
-    InterledgerAddress selfAddress = AllocationScheme.SELF.with("bob.baz");
-    InterledgerAddress testAddress = AllocationScheme.TEST.with("bob.baz");
-    InterledgerAddress test1Address = AllocationScheme.TEST1.with("bob.baz");
-    InterledgerAddress test2Address = AllocationScheme.TEST2.with("bob.baz");
-    InterledgerAddress test3Address = AllocationScheme.TEST3.with("bob.baz");
-
-    assertThat(globalAddress.getAllocationScheme()).isEqualTo(AllocationScheme.GLOBAL);
-    assertThat(globalAddress.getValue()).isEqualTo("g.bob.baz");
-
-    assertThat(exampleAddress.getAllocationScheme()).isEqualTo(AllocationScheme.EXAMPLE);
-    assertThat(exampleAddress.getValue()).isEqualTo("example.bob.baz");
-
-    assertThat(peerAddress.getAllocationScheme()).isEqualTo(AllocationScheme.PEER);
-    assertThat(peerAddress.getValue()).isEqualTo("peer.bob.baz");
-
-    assertThat(privateAddress.getAllocationScheme()).isEqualTo(AllocationScheme.PRIVATE);
-    assertThat(privateAddress.getValue()).isEqualTo("private.bob.baz");
-
-    assertThat(selfAddress.getAllocationScheme()).isEqualTo(AllocationScheme.SELF);
-    assertThat(selfAddress.getValue()).isEqualTo("self.bob.baz");
-
-    assertThat(testAddress.getAllocationScheme()).isEqualTo(AllocationScheme.TEST);
-    assertThat(testAddress.getValue()).isEqualTo("test.bob.baz");
-
-    assertThat(test1Address.getAllocationScheme()).isEqualTo(AllocationScheme.TEST1);
-    assertThat(test1Address.getValue()).isEqualTo("test1.bob.baz");
-
-    assertThat(test2Address.getAllocationScheme()).isEqualTo(AllocationScheme.TEST2);
-    assertThat(test2Address.getValue()).isEqualTo("test2.bob.baz");
-
-    assertThat(test3Address.getAllocationScheme()).isEqualTo(AllocationScheme.TEST3);
-    assertThat(test3Address.getValue()).isEqualTo("test3.bob.baz");
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testInterledgerAddressCreationWithNull() {
-    try {
-      AllocationScheme.GLOBAL.with(null);
-      fail("should have failed and the error been caught");
-    } catch (NullPointerException e) {
-      assertThat(e.getMessage()).isEqualTo("value must not be null!");
-      throw e;
-    }
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testInterledgerAddressCreationWithEmpty() {
-    try {
-      AllocationScheme.GLOBAL.with("");
-      fail("should have failed and the error been caught");
-    } catch (IllegalArgumentException e) {
-      assertThat(e.getMessage()).isEqualTo(ILLEGAL_ENDING.getMessageFormat());
-      throw e;
-    }
-  }
-
-  @Test
   public void testGetPrefixFromShortPrefix() {
     assertThat(InterledgerAddress.of("g.1").getPrefix().getValue().isEmpty()).isFalse();
     assertThat(InterledgerAddress.of("g.1").getPrefix()).isEqualTo(InterledgerAddressPrefix.of("g"));
@@ -585,6 +517,4 @@ public class InterledgerAddressTest {
       throw e;
     }
   }
-
-
 }

--- a/jackson-datatypes/pom.xml
+++ b/jackson-datatypes/pom.xml
@@ -15,6 +15,14 @@
 
   <dependencies>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>ilp-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>link-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>
@@ -42,10 +50,6 @@
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>ilp-core</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/jackson-datatypes/src/main/java/org/interledger/quilt/jackson/link/LinkIdDeserializer.java
+++ b/jackson-datatypes/src/main/java/org/interledger/quilt/jackson/link/LinkIdDeserializer.java
@@ -1,0 +1,24 @@
+package org.interledger.quilt.jackson.link;
+
+import org.interledger.link.LinkId;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+
+/**
+ * Jackson deserializer for {@link LinkId}.
+ */
+public class LinkIdDeserializer extends StdDeserializer<LinkId> {
+
+  protected LinkIdDeserializer() {
+    super(LinkId.class);
+  }
+
+  @Override
+  public LinkId deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException {
+    return LinkId.of(jsonParser.getText());
+  }
+}

--- a/jackson-datatypes/src/main/java/org/interledger/quilt/jackson/link/LinkIdModule.java
+++ b/jackson-datatypes/src/main/java/org/interledger/quilt/jackson/link/LinkIdModule.java
@@ -1,0 +1,24 @@
+package org.interledger.quilt.jackson.link;
+
+import org.interledger.link.LinkId;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+/**
+ * A Jackson {@link SimpleModule} for serializing and deserializing instances of {@link LinkId}.
+ */
+public class LinkIdModule extends SimpleModule {
+
+  private static final String NAME = "LinkIdModule";
+
+  /**
+   * No-args Constructor.
+   */
+  public LinkIdModule() {
+    super(NAME, new Version(1, 0, 0, null, "org.interledger", "link-id"));
+
+    addSerializer(LinkId.class, new LinkIdSerializer());
+    addDeserializer(LinkId.class, new LinkIdDeserializer());
+  }
+}

--- a/jackson-datatypes/src/main/java/org/interledger/quilt/jackson/link/LinkIdSerializer.java
+++ b/jackson-datatypes/src/main/java/org/interledger/quilt/jackson/link/LinkIdSerializer.java
@@ -1,0 +1,24 @@
+package org.interledger.quilt.jackson.link;
+
+import org.interledger.link.LinkId;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
+
+import java.io.IOException;
+
+/**
+ * Jackson serializer {@link LinkId}.
+ */
+public class LinkIdSerializer extends StdScalarSerializer<LinkId> {
+
+  public LinkIdSerializer() {
+    super(LinkId.class, false);
+  }
+
+  @Override
+  public void serialize(LinkId linkId, JsonGenerator gen, SerializerProvider provider) throws IOException {
+    gen.writeString(linkId.value());
+  }
+}

--- a/jackson-datatypes/src/main/java/org/interledger/quilt/jackson/link/LinkTypeDeserializer.java
+++ b/jackson-datatypes/src/main/java/org/interledger/quilt/jackson/link/LinkTypeDeserializer.java
@@ -1,0 +1,24 @@
+package org.interledger.quilt.jackson.link;
+
+import org.interledger.link.LinkType;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+
+/**
+ * Jackson deserializer for {@link LinkType}.
+ */
+public class LinkTypeDeserializer extends StdDeserializer<LinkType> {
+
+  protected LinkTypeDeserializer() {
+    super(LinkType.class);
+  }
+
+  @Override
+  public LinkType deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException {
+    return LinkType.of(jsonParser.getText());
+  }
+}

--- a/jackson-datatypes/src/main/java/org/interledger/quilt/jackson/link/LinkTypeModule.java
+++ b/jackson-datatypes/src/main/java/org/interledger/quilt/jackson/link/LinkTypeModule.java
@@ -1,0 +1,24 @@
+package org.interledger.quilt.jackson.link;
+
+import org.interledger.link.LinkType;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+/**
+ * A Jackson {@link SimpleModule} for serializing and deserializing instances of {@link LinkType}.
+ */
+public class LinkTypeModule extends SimpleModule {
+
+  private static final String NAME = "LinkTypeModule";
+
+  /**
+   * No-args Constructor.
+   */
+  public LinkTypeModule() {
+    super(NAME, new Version(1, 0, 0, null, "org.interledger", "link-type"));
+
+    addSerializer(LinkType.class, new LinkTypeSerializer());
+    addDeserializer(LinkType.class, new LinkTypeDeserializer());
+  }
+}

--- a/jackson-datatypes/src/main/java/org/interledger/quilt/jackson/link/LinkTypeSerializer.java
+++ b/jackson-datatypes/src/main/java/org/interledger/quilt/jackson/link/LinkTypeSerializer.java
@@ -1,0 +1,24 @@
+package org.interledger.quilt.jackson.link;
+
+import org.interledger.link.LinkType;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
+
+import java.io.IOException;
+
+/**
+ * Jackson serializer {@link LinkType}.
+ */
+public class LinkTypeSerializer extends StdScalarSerializer<LinkType> {
+
+  public LinkTypeSerializer() {
+    super(LinkType.class, false);
+  }
+
+  @Override
+  public void serialize(LinkType linkType, JsonGenerator gen, SerializerProvider provider) throws IOException {
+    gen.writeString(linkType.value());
+  }
+}

--- a/jackson-datatypes/src/test/java/org/interledger/quilt/jackson/link/LinkIdContainer.java
+++ b/jackson-datatypes/src/test/java/org/interledger/quilt/jackson/link/LinkIdContainer.java
@@ -1,0 +1,22 @@
+package org.interledger.quilt.jackson.link;
+
+import org.interledger.link.LinkId;
+import org.interledger.quilt.jackson.link.ImmutableLinkIdContainer.Builder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableLinkIdContainer.class)
+@JsonDeserialize(as = ImmutableLinkIdContainer.class)
+public interface LinkIdContainer {
+
+  static Builder builder() {
+    return ImmutableLinkIdContainer.builder();
+  }
+
+  @JsonProperty("link_id")
+  LinkId getLinkId();
+}

--- a/jackson-datatypes/src/test/java/org/interledger/quilt/jackson/link/LinkIdDeserializerTest.java
+++ b/jackson-datatypes/src/test/java/org/interledger/quilt/jackson/link/LinkIdDeserializerTest.java
@@ -1,0 +1,45 @@
+package org.interledger.quilt.jackson.link;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import org.interledger.link.LinkId;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Unit tests for {@link LinkIdDeserializer}.
+ */
+public class LinkIdDeserializerTest {
+
+  private LinkId LINK_ID = LinkId.of(UUID.randomUUID().toString());
+
+  private ObjectMapper objectMapper = new ObjectMapper()
+      .registerModule(new LinkIdModule());
+
+  @Test
+  public void shouldDeserialize() throws IOException {
+    final LinkId actual = objectMapper
+        .readValue("\"" + LINK_ID.value() + "\"", LinkId.class);
+
+    assertThat(actual).isEqualTo(LINK_ID);
+  }
+
+  @Test
+  public void shouldDeserializeInContainer() throws IOException {
+    final LinkIdContainer expectedContainer = LinkIdContainer.builder()
+        .linkId(LINK_ID)
+        .build();
+
+    final LinkIdContainer actualContainer = objectMapper.readValue(
+        "{\"link_id\":\"" + LINK_ID.value() + "\"}",
+        LinkIdContainer.class
+    );
+
+    assertThat(actualContainer).isEqualTo(expectedContainer);
+  }
+
+}

--- a/jackson-datatypes/src/test/java/org/interledger/quilt/jackson/link/LinkIdSerializerTest.java
+++ b/jackson-datatypes/src/test/java/org/interledger/quilt/jackson/link/LinkIdSerializerTest.java
@@ -1,0 +1,39 @@
+package org.interledger.quilt.jackson.link;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import org.interledger.link.LinkId;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Unit tests for {@link LinkIdSerializer}.
+ */
+public class LinkIdSerializerTest {
+
+  private LinkId LINK_ID = LinkId.of(UUID.randomUUID().toString());
+
+  private ObjectMapper objectMapper = new ObjectMapper()
+      .registerModule(new LinkIdModule());
+
+  @Test
+  public void shouldSerialize() throws IOException {
+    final String actual = objectMapper.writeValueAsString(LINK_ID);
+    assertThat(actual).isEqualTo("\"" + LINK_ID.value() + "\"");
+  }
+
+  @Test
+  public void shouldSerializeInContainer() throws IOException {
+    final LinkIdContainer expectedContainer = LinkIdContainer.builder()
+        .linkId(LINK_ID)
+        .build();
+
+    final String actualJson = objectMapper.writeValueAsString(expectedContainer);
+
+    assertThat(actualJson).isEqualTo("{\"link_id\":\"" + LINK_ID.value() + "\"}");
+  }
+}

--- a/jackson-datatypes/src/test/java/org/interledger/quilt/jackson/link/LinkModuleTest.java
+++ b/jackson-datatypes/src/test/java/org/interledger/quilt/jackson/link/LinkModuleTest.java
@@ -1,0 +1,54 @@
+package org.interledger.quilt.jackson.link;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import org.interledger.link.LinkId;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Unit tests for {@link LinkIdModule}.
+ */
+public class LinkModuleTest {
+
+  private static final LinkId LINK_ID = LinkId.of(UUID.randomUUID().toString());
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void shouldSerializeAndDeserialize() throws IOException {
+    ObjectMapper objectMapper = new ObjectMapper()
+        .registerModule(new LinkIdModule());
+
+    final LinkIdContainer expectedContainer = LinkIdContainer.builder()
+        .linkId(LINK_ID)
+        .build();
+
+    final String actualJson = objectMapper.writeValueAsString(expectedContainer);
+    final LinkIdContainer decodedJson = objectMapper.readValue(actualJson, LinkIdContainer.class);
+
+    assertThat(decodedJson).isEqualTo(expectedContainer);
+  }
+
+  @Test
+  public void shouldNotDeserialize() throws IOException {
+    ObjectMapper objectMapperWithoutModule = new ObjectMapper(); // No Module!
+
+    final LinkIdContainer expectedContainer = LinkIdContainer.builder()
+        .linkId(LINK_ID)
+        .build();
+
+    expectedException.expect(MismatchedInputException.class);
+    final String json = objectMapperWithoutModule.writeValueAsString(expectedContainer);
+    objectMapperWithoutModule.readValue(json, LinkIdContainer.class);
+  }
+
+}

--- a/jackson-datatypes/src/test/java/org/interledger/quilt/jackson/link/LinkTypeContainer.java
+++ b/jackson-datatypes/src/test/java/org/interledger/quilt/jackson/link/LinkTypeContainer.java
@@ -1,0 +1,22 @@
+package org.interledger.quilt.jackson.link;
+
+import org.interledger.link.LinkType;
+import org.interledger.quilt.jackson.link.ImmutableLinkTypeContainer.Builder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableLinkTypeContainer.class)
+@JsonDeserialize(as = ImmutableLinkTypeContainer.class)
+public interface LinkTypeContainer {
+
+  static Builder builder() {
+    return ImmutableLinkTypeContainer.builder();
+  }
+
+  @JsonProperty("link_type")
+  LinkType getLinkType();
+}

--- a/jackson-datatypes/src/test/java/org/interledger/quilt/jackson/link/LinkTypeIdDeserializerTest.java
+++ b/jackson-datatypes/src/test/java/org/interledger/quilt/jackson/link/LinkTypeIdDeserializerTest.java
@@ -1,0 +1,45 @@
+package org.interledger.quilt.jackson.link;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import org.interledger.link.LinkType;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Unit tests for {@link LinkTypeDeserializer}.
+ */
+public class LinkTypeIdDeserializerTest {
+
+  private LinkType LINK_TYPE = LinkType.of(UUID.randomUUID().toString());
+
+  private ObjectMapper objectMapper = new ObjectMapper()
+      .registerModule(new LinkTypeModule());
+
+  @Test
+  public void shouldDeserialize() throws IOException {
+    final LinkType actual = objectMapper
+        .readValue("\"" + LINK_TYPE.value() + "\"", LinkType.class);
+
+    assertThat(actual).isEqualTo(LINK_TYPE);
+  }
+
+  @Test
+  public void shouldDeserializeInContainer() throws IOException {
+    final LinkTypeContainer expectedContainer = LinkTypeContainer.builder()
+        .linkType(LINK_TYPE)
+        .build();
+
+    final LinkTypeContainer actualContainer = objectMapper.readValue(
+        "{\"link_type\":\"" + LINK_TYPE.value() + "\"}",
+        LinkTypeContainer.class
+    );
+
+    assertThat(actualContainer).isEqualTo(expectedContainer);
+  }
+
+}

--- a/jackson-datatypes/src/test/java/org/interledger/quilt/jackson/link/LinkTypeModuleTest.java
+++ b/jackson-datatypes/src/test/java/org/interledger/quilt/jackson/link/LinkTypeModuleTest.java
@@ -1,0 +1,51 @@
+package org.interledger.quilt.jackson.link;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import org.interledger.link.LinkType;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Unit tests for {@link LinkTypeModule}.
+ */
+public class LinkTypeModuleTest {
+
+  private static final LinkType LINK_TYPE = LinkType.of(UUID.randomUUID().toString());
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void shouldSerializeAndDeserializeWithModule() throws IOException {
+    ObjectMapper objectMapper = new ObjectMapper()
+        .registerModule(new LinkTypeModule());
+    final LinkTypeContainer expectedContainer = LinkTypeContainer.builder()
+        .linkType(LINK_TYPE)
+        .build();
+
+    final String actualJson = objectMapper.writeValueAsString(expectedContainer);
+    final LinkTypeContainer decodedJson = objectMapper.readValue(actualJson, LinkTypeContainer.class);
+    assertThat(decodedJson).isEqualTo(expectedContainer);
+  }
+
+  @Test
+  public void shouldNotDeserialize() throws IOException {
+    ObjectMapper objectMapperWithoutModule = new ObjectMapper();  // No Module!
+    final LinkTypeContainer expectedContainer = LinkTypeContainer.builder()
+        .linkType(LINK_TYPE)
+        .build();
+
+    expectedException.expect(MismatchedInputException.class);
+    final String json = objectMapperWithoutModule.writeValueAsString(expectedContainer);
+    objectMapperWithoutModule.readValue(json, LinkTypeContainer.class);
+  }
+
+}

--- a/jackson-datatypes/src/test/java/org/interledger/quilt/jackson/link/LinkTypeSerializerTest.java
+++ b/jackson-datatypes/src/test/java/org/interledger/quilt/jackson/link/LinkTypeSerializerTest.java
@@ -1,0 +1,39 @@
+package org.interledger.quilt.jackson.link;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import org.interledger.link.LinkType;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Unit tests for {@link LinkTypeSerializer}.
+ */
+public class LinkTypeSerializerTest {
+
+  private LinkType LINK_TYPE = LinkType.of(UUID.randomUUID().toString());
+
+  private ObjectMapper objectMapper = new ObjectMapper()
+      .registerModule(new LinkTypeModule());
+
+  @Test
+  public void shouldSerialize() throws IOException {
+    final String actual = objectMapper.writeValueAsString(LINK_TYPE);
+    assertThat(actual).isEqualTo("\"" + LINK_TYPE.value() + "\"");
+  }
+
+  @Test
+  public void shouldSerializeInContainer() throws IOException {
+    final LinkTypeContainer expectedContainer = LinkTypeContainer.builder()
+        .linkType(LINK_TYPE)
+        .build();
+
+    final String actualJson = objectMapper.writeValueAsString(expectedContainer);
+
+    assertThat(actualJson).isEqualTo("{\"link_type\":\"" + LINK_TYPE.value() + "\"}");
+  }
+}


### PR DESCRIPTION
* Fixes #362 to account for the `local` AllocationScheme.
* Adds Jackson support for `LinkId` and `LinkType`
* Improve unit test coverage.