### PR TITLE
DCO Attestation for prior commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,3 +226,4 @@ $ mvn checkstyle:checkstyle
 [twitter-url]: https://twitter.com/intent/follow?screen_name=interledger
 [github-issues-image]: https://img.shields.io/github/issues/hyperledger/quilt.svg
 [github-issues-url]: https://github.com/hyperledger/quilt/issues
+ 


### PR DESCRIPTION
The following commit hashes are missing their DCO sign-off, but I attest these commits were made by me.

* 33082e4cc2ded3fafbfb26fb42d804bfd8e7edd7
* 2703db00ad5d43cfed66cdf35e0d77c6b110a9fc

Signed-off-by: David Fuelling <sappenin@gmail.com>