### PR TITLE
Refactor SPSP client to its own client not coupled to Rust client

### DIFF
--- a/examples-parent/send-money/README.md
+++ b/examples-parent/send-money/README.md
@@ -1,6 +1,6 @@
 # Send Money over ILP using Quilt
 
-This tutorial shows how to use the Quilt library to send money from one ILP rustNodeAccount to another 
+This tutorial shows how to use the Quilt library to send money from one ILP account to another 
 (via a [STREAM](https://interledger.org/rfcs/0029-stream/) payment) using the ILP Testnet. 
 Complete working code for this tutorial can be found in [SendMoneyExample](./src/main/java/org/interledger/examples/SendMoneyExample.java)
 
@@ -9,7 +9,7 @@ Complete working code for this tutorial can be found in [SendMoneyExample](./src
 For this example, we need 2 different accounts on ILP Testnet, a sender and a receiver. You can create 
 accounts using the **Generate XRP Credentials** button on https://xpring.io/ilp-testnet-creds
 
-In this example, we will use the following rustNodeAccount details:
+In this example, we will use the following account details:
 
 Sender:
 - Username: user_qb4yklwd
@@ -27,15 +27,15 @@ Receiver:
 
 High-level approach:
 - Fetch the shared secret and destination address. We'll use Quilt's [SimpleSpspClient](../../spsp-parent/spsp-client/src/main/java/org/interledger/spsp/client/SimpleSpspClient.java)
-since our Testnet rustNodeAccount was created on an ILP node running  [Interledger.rs](https://github.com/interledger-rs/interledger-rs). 
+since our Testnet account was created on an ILP node running  [Interledger.rs](https://github.com/interledger-rs/interledger-rs). 
 - Create an [ILP over HTTP](https://interledger.org/rfcs/0035-ilp-over-http/) link using Quilt's 
 [IlpOverHttpLink](../../link-parent/link-ilp-over-http/src/main/java/org/interledger/link/http/IlpOverHttpLink.java). 
 - Create a STREAM connection using Quilt's [SimpleStreamSender](../../stream-parent/stream-client/src/main/java/org/interledger/stream/sender/SimpleStreamSender.java)
-- Send money to the receiver rustNodeAccount's payment pointer using the `sendMoney` method on `SimpleStreamSender`
+- Send money to the receiver account's payment pointer using the `sendMoney` method on `SimpleStreamSender`
 
 ## Code
 
-The following constants are used in the code snippets. These should be replaced with your own rustNodeAccount values:
+The following constants are used in the code snippets. These should be replaced with your own account values:
 ```java
 private static final String SENDER_ACCOUNT_USERNAME = "user_qb4yklwd";
 private static final String SENDER_PASS_KEY = "jxelaxvqz2ne6";
@@ -84,13 +84,13 @@ Using this `link`, we can now create a `SimpleStreamSender`:
 SimpleStreamSender simpleStreamSender = new SimpleStreamSender(link);
 ```
 
-Now, we can send a payment for 1000 millidrops from our source rustNodeAccount to our destination rustNodeAccount using the shared secret.
+Now, we can send a payment for 1000 millidrops from our source account to our destination account using the shared secret.
 ```java
 SendMoneyResult result = simpleStreamSender.sendMoney(SharedSecret.of(connectionDetails.sharedSecret().value()),
     SENDER_ADDRESS, connectionDetails.destinationAddress(), UnsignedLong.valueOf(1000)).get();
 ```
 
-Finally, we can verify the rustNodeAccount balance of the receiver using the Rust admin client:
+Finally, we can verify the account balance of the receiver using the Rust admin client:
 ```java
 InterledgerRustNodeClient rustClient =
     new InterledgerRustNodeClient(newHttpClient(), SENDER_ACCOUNT_USERNAME + ":" + SENDER_PASS_KEY, TESTNET_URI);

--- a/examples-parent/send-money/src/main/java/org/interledger/examples/SendMoneyExample.java
+++ b/examples-parent/send-money/src/main/java/org/interledger/examples/SendMoneyExample.java
@@ -13,6 +13,8 @@ import org.interledger.link.http.OutgoingLinkSettings;
 import org.interledger.link.http.auth.SimpleBearerTokenSupplier;
 import org.interledger.spsp.PaymentPointer;
 import org.interledger.spsp.StreamConnectionDetails;
+import org.interledger.spsp.client.SimpleSpspClient;
+import org.interledger.spsp.client.SpspClient;
 import org.interledger.spsp.client.rust.InterledgerRustNodeClient;
 import org.interledger.stream.Denominations;
 import org.interledger.stream.SendMoneyRequest;
@@ -39,11 +41,11 @@ import java.util.concurrent.TimeUnit;
 public class SendMoneyExample {
 
   // NOTE - replace this with the username for your sender account
-  private static final String SENDER_ACCOUNT_USERNAME = "user_ju7z53sh";
+  private static final String SENDER_ACCOUNT_USERNAME = "user_9wgfsfte";
   // NOTE - replace this with the passkey for your sender account
-  private static final String SENDER_PASS_KEY = "lzjtsi4ny5f09";
+  private static final String SENDER_PASS_KEY = "w6uwvg42ogktl";
   // NOTE - replace this with the payment pointer for your receiver account
-  private static final String RECEIVER_PAYMENT_POINTER = "$rs3.xpring.dev/accounts/user_f5zfkf4a/spsp";
+  private static final String RECEIVER_PAYMENT_POINTER = "$rs3.xpring.dev/accounts/user_e8zprn59/spsp";
 
   private static final String TESTNET_URI = "https://rs3.xpring.dev";
 
@@ -51,8 +53,10 @@ public class SendMoneyExample {
       InterledgerAddress.of("test.xpring-dev.rs3").with(SENDER_ACCOUNT_USERNAME);
 
   public static void main(String[] args) throws ExecutionException, InterruptedException {
-    // Create SPSP client
-    InterledgerRustNodeClient spspClient =
+    SpspClient spspClient = new SimpleSpspClient();
+
+    // Create rust client
+    InterledgerRustNodeClient rustClient =
         new InterledgerRustNodeClient(newHttpClient(), SENDER_ACCOUNT_USERNAME + ":" + SENDER_PASS_KEY, TESTNET_URI);
 
     // Fetch shared secret and destination address using SPSP client
@@ -65,7 +69,7 @@ public class SendMoneyExample {
     // Create SimpleStreamSender for sending STREAM payments
     SimpleStreamSender simpleStreamSender = new SimpleStreamSender(link);
 
-    System.out.println("Starting balance for sender: " + spspClient.getBalance(SENDER_ACCOUNT_USERNAME));
+    System.out.println("Starting balance for sender: " + rustClient.getBalance(SENDER_ACCOUNT_USERNAME));
 
     // Send payment using STREAM
     SendMoneyResult result = simpleStreamSender.sendMoney(
@@ -82,7 +86,7 @@ public class SendMoneyExample {
     ).get();
 
     System.out.println("Send money result: " + result);
-    System.out.println("Ending balance for sender: " + spspClient.getBalance(SENDER_ACCOUNT_USERNAME));
+    System.out.println("Ending balance for sender: " + rustClient.getBalance(SENDER_ACCOUNT_USERNAME));
   }
 
   private static Link newIlpOverHttpLink() {

--- a/spsp-parent/spsp-client/src/main/java/org/interledger/spsp/client/SimpleSpspClient.java
+++ b/spsp-parent/spsp-client/src/main/java/org/interledger/spsp/client/SimpleSpspClient.java
@@ -1,0 +1,68 @@
+package org.interledger.spsp.client;
+
+import org.interledger.spsp.PaymentPointer;
+import org.interledger.spsp.PaymentPointerResolver;
+import org.interledger.spsp.StreamConnectionDetails;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+
+/**
+ * Basic implementation of an {@link SpspClient} that uses default okhttp3 client and jackson mapper.
+ */
+public class SimpleSpspClient implements SpspClient {
+
+  private final OkHttpClient httpClient;
+
+  private final PaymentPointerResolver paymentPointerResolver;
+
+  private final ObjectMapper objectMapper;
+
+  public SimpleSpspClient() {
+    this(SpspClientDefaults.OK_HTTP_CLIENT, PaymentPointerResolver.defaultResolver(), SpspClientDefaults.MAPPER);
+  }
+
+  public SimpleSpspClient(OkHttpClient httpClient,
+                          PaymentPointerResolver paymentPointerResolver,
+                          ObjectMapper objectMapper) {
+    this.httpClient = httpClient;
+    this.paymentPointerResolver = paymentPointerResolver;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public StreamConnectionDetails getStreamConnectionDetails(PaymentPointer paymentPointer)
+      throws InvalidReceiverClientException {
+    return getStreamConnectionDetails(HttpUrl.parse(paymentPointerResolver.resolve(paymentPointer)));
+  }
+
+  @Override
+  public StreamConnectionDetails getStreamConnectionDetails(HttpUrl spspUrl) throws InvalidReceiverClientException {
+    return execute(new Request.Builder()
+        .url(spspUrl)
+        .header("Accept", ACCEPT_SPSP_JSON)
+        .get()
+        .build(), StreamConnectionDetails.class);
+  }
+
+  private <T> T execute(Request request, Class<T> clazz) throws SpspClientException {
+    try (Response response = httpClient.newCall(request).execute()) {
+      if (!response.isSuccessful()) {
+        if (response.code() == 404) {
+          throw new InvalidReceiverClientException(request.url().toString());
+        }
+        throw new SpspClientException("Received non-successful HTTP response code " + response.code()
+            + " calling " + request.url());
+      }
+      return objectMapper.readValue(response.body().string(), clazz);
+    } catch (IOException e) {
+      throw new SpspClientException("IOException failure calling " + request.url(), e);
+    }
+  }
+
+}

--- a/spsp-parent/spsp-client/src/main/java/org/interledger/spsp/client/SpspClient.java
+++ b/spsp-parent/spsp-client/src/main/java/org/interledger/spsp/client/SpspClient.java
@@ -3,6 +3,8 @@ package org.interledger.spsp.client;
 import org.interledger.spsp.PaymentPointer;
 import org.interledger.spsp.StreamConnectionDetails;
 
+import okhttp3.HttpUrl;
+
 /**
  * Client operations related to SPSP.
  *
@@ -22,5 +24,17 @@ public interface SpspClient {
    */
   StreamConnectionDetails getStreamConnectionDetails(PaymentPointer paymentPointer)
       throws InvalidReceiverClientException;
+
+  /**
+   * Calls SPSP endpoint to obtain address and secret needed to setup a payment (for the given SPSP url).
+   * Typically used for setting up a STREAM connection.
+   * @see "https://github.com/interledger/rfcs/blob/master/0009-simple-payment-setup-protocol/0009-simple-payment-setup-protocol.md#query-get-spsp-endpoint"
+   * @param spspUrl url for the SPSP account endpoint
+   * @return stream connection details
+   * @throws InvalidReceiverClientException thrown if the payment pointer does not point to a valid account
+   */
+  StreamConnectionDetails getStreamConnectionDetails(HttpUrl spspUrl)
+      throws InvalidReceiverClientException;
+
 
 }

--- a/spsp-parent/spsp-client/src/main/java/org/interledger/spsp/client/SpspClientDefaults.java
+++ b/spsp-parent/spsp-client/src/main/java/org/interledger/spsp/client/SpspClientDefaults.java
@@ -1,0 +1,57 @@
+package org.interledger.spsp.client;
+
+import static okhttp3.CookieJar.NO_COOKIES;
+
+import org.interledger.quilt.jackson.InterledgerModule;
+import org.interledger.quilt.jackson.conditions.Encoding;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.json.JsonWriteFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import okhttp3.ConnectionPool;
+import okhttp3.ConnectionSpec;
+import okhttp3.OkHttpClient;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Holder for default instances of components needed by SPSP clients
+ */
+public class SpspClientDefaults {
+
+  public static final ObjectMapper MAPPER = defaultMapper();
+
+  public static final OkHttpClient OK_HTTP_CLIENT = defaultHttpClient();
+
+  private static ObjectMapper defaultMapper() {
+    final ObjectMapper objectMapper = JsonMapper.builder()
+        .serializationInclusion(JsonInclude.Include.NON_EMPTY)
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .configure(JsonWriteFeature.WRITE_NUMBERS_AS_STRINGS, false)
+        .build()
+        .registerModule(new Jdk8Module())
+        .registerModule(new InterledgerModule(Encoding.BASE64));
+    objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+    objectMapper.configure(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN, true);
+    return objectMapper;
+  }
+
+  private static OkHttpClient defaultHttpClient() {
+    ConnectionPool connectionPool = new ConnectionPool(10, 5, TimeUnit.MINUTES);
+    ConnectionSpec spec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS).build();
+    OkHttpClient.Builder builder = new OkHttpClient.Builder()
+        .connectionSpecs(Arrays.asList(spec, ConnectionSpec.CLEARTEXT))
+        .cookieJar(NO_COOKIES)
+        .connectTimeout(5000, TimeUnit.MILLISECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .writeTimeout(30, TimeUnit.SECONDS);
+    return builder.connectionPool(connectionPool).build();
+  }
+
+}

--- a/spsp-parent/spsp-client/src/main/java/org/interledger/spsp/client/rust/InterledgerRustNodeClient.java
+++ b/spsp-parent/spsp-client/src/main/java/org/interledger/spsp/client/rust/InterledgerRustNodeClient.java
@@ -1,24 +1,12 @@
 package org.interledger.spsp.client.rust;
 
-import org.interledger.quilt.jackson.InterledgerModule;
-import org.interledger.quilt.jackson.conditions.Encoding;
-import org.interledger.spsp.PaymentPointer;
-import org.interledger.spsp.PaymentPointerResolver;
-import org.interledger.spsp.StreamConnectionDetails;
+import org.interledger.spsp.client.SpspClientDefaults;
 import org.interledger.spsp.client.InvalidReceiverClientException;
-import org.interledger.spsp.client.SpspClient;
 import org.interledger.spsp.client.SpspClientException;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.json.JsonWriteFeature;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableMap;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
@@ -32,7 +20,10 @@ import org.immutables.value.Value.Immutable;
 import java.io.IOException;
 import java.math.BigDecimal;
 
-public class InterledgerRustNodeClient implements SpspClient {
+/**
+ * Client for interacting with API on a Rust Interledger Node.
+ */
+public class InterledgerRustNodeClient {
 
   public static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
 
@@ -40,60 +31,26 @@ public class InterledgerRustNodeClient implements SpspClient {
   private final String authToken;
   private final ObjectMapper objectMapper;
   private final String baseUri;
-  private final PaymentPointerResolver paymentPointerResolver;
-
-  private static final ObjectMapper MAPPER = mapper();
-
-  private static ObjectMapper mapper() {
-    final ObjectMapper objectMapper = JsonMapper.builder()
-        .serializationInclusion(JsonInclude.Include.NON_EMPTY)
-        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        .configure(JsonWriteFeature.WRITE_NUMBERS_AS_STRINGS, false)
-        .build()
-        .registerModule(new Jdk8Module())
-        .registerModule(new InterledgerModule(Encoding.BASE64));
-    objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-    objectMapper.configure(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN, true);
-    return objectMapper;
-  }
 
   public InterledgerRustNodeClient(OkHttpClient okHttpClient,
                                    String authToken,
                                    String baseUri) {
-    this(okHttpClient, authToken, baseUri, PaymentPointerResolver.defaultResolver());
-  }
-
-  public InterledgerRustNodeClient(OkHttpClient okHttpClient,
-                                   String authToken,
-                                   String baseUri,
-                                   PaymentPointerResolver paymentPointerResolver) {
     this.httpClient = okHttpClient;
     this.authToken = authToken;
-    this.objectMapper = MAPPER;
+    this.objectMapper = SpspClientDefaults.MAPPER;
     this.baseUri = baseUri;
-    this.paymentPointerResolver = paymentPointerResolver;
   }
 
-  public Account createAccount(Account account) throws IOException {
+  public RustNodeAccount createAccount(RustNodeAccount rustNodeAccount) throws IOException {
     return execute(requestBuilder()
       .url(HttpUrl.parse(baseUri + "/accounts"))
-      .post(RequestBody.create(objectMapper.writeValueAsString(account), JSON))
-      .build(), Account.class);
+      .post(RequestBody.create(objectMapper.writeValueAsString(rustNodeAccount), JSON))
+      .build(), RustNodeAccount.class);
   }
 
   private Request.Builder requestBuilder() {
     return new Request.Builder()
       .headers(Headers.of(ImmutableMap.of("Authorization", "Bearer " + authToken)));
-  }
-
-  public StreamConnectionDetails getStreamConnectionDetails(PaymentPointer paymentPointer)
-      throws InvalidReceiverClientException {
-    return execute(requestBuilder()
-      .url(HttpUrl.parse(paymentPointerResolver.resolve(paymentPointer)))
-      .headers(Headers.of(ImmutableMap.of("Authorization", "Bearer " + authToken,
-        "Accept", ACCEPT_SPSP_JSON)))
-      .get()
-      .build(), StreamConnectionDetails.class);
   }
 
   public BigDecimal getBalance(String accountName) throws SpspClientException {

--- a/spsp-parent/spsp-client/src/main/java/org/interledger/spsp/client/rust/RustNodeAccount.java
+++ b/spsp-parent/spsp-client/src/main/java/org/interledger/spsp/client/rust/RustNodeAccount.java
@@ -18,12 +18,12 @@ import java.util.Optional;
  * @see "https://github.com/interledger-rs/interledger-rs/blob/master/docs/api.md"
  */
 @Value.Immutable
-@JsonSerialize(as = ImmutableAccount.class)
-@JsonDeserialize(builder = ImmutableAccount.Builder.class)
-public interface Account {
+@JsonSerialize(as = ImmutableRustNodeAccount.class)
+@JsonDeserialize(builder = ImmutableRustNodeAccount.Builder.class)
+public interface RustNodeAccount {
 
-  static ImmutableAccount.Builder builder() {
-    return ImmutableAccount.builder();
+  static ImmutableRustNodeAccount.Builder builder() {
+    return ImmutableRustNodeAccount.builder();
   }
 
   /**

--- a/spsp-parent/spsp-client/src/test/java/org/interledger/spsp/client/SimpleSpspClientTest.java
+++ b/spsp-parent/spsp-client/src/test/java/org/interledger/spsp/client/SimpleSpspClientTest.java
@@ -1,0 +1,113 @@
+package org.interledger.spsp.client;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.interledger.core.InterledgerAddress;
+import org.interledger.core.SharedSecret;
+import org.interledger.spsp.PaymentPointer;
+import org.interledger.spsp.StreamConnectionDetails;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import okhttp3.HttpUrl;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SimpleSpspClientTest {
+
+  @Rule
+  public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
+  private SpspClient client;
+
+  @Before
+  public void setUp() {
+    client = new SimpleSpspClient(SpspClientDefaults.OK_HTTP_CLIENT,
+        (pointer) -> wireMockRule.baseUrl() + pointer.path(),
+        SpspClientDefaults.MAPPER);
+  }
+
+  @Test
+  public void getStreamConnectionDetailsFromPaymentPointer() {
+    String testClient = "testClient";
+    String sharedSecret = "Nf9wCXI1OZLM/QIWdZZ2Q39limh6+Yxhm/FB1bUpZLA=";
+
+    String wiremockIlpAddress = "test.wiremock";
+    stubFor(get(urlEqualTo("/" + testClient))
+        .withHeader("Accept", equalTo(SpspClient.ACCEPT_SPSP_JSON))
+        .willReturn(aResponse()
+            .withStatus(200)
+            .withBody("{\"destination_account\":\"" + wiremockIlpAddress + "." + testClient + "\","
+                + "\"shared_secret\":\"" + sharedSecret + "\"}")
+        ));
+
+    StreamConnectionDetails response =
+        client.getStreamConnectionDetails(paymentPointer(testClient));
+
+    assertThat(response)
+        .isEqualTo(StreamConnectionDetails.builder()
+            .destinationAddress(InterledgerAddress.of(wiremockIlpAddress + "." + testClient))
+            .sharedSecret(SharedSecret.of(sharedSecret))
+            .build());
+  }
+
+  @Test
+  public void getStreamConnectionDetailsFromUrl() {
+    String testClient = "testClient";
+    String sharedSecret = "Nf9wCXI1OZLM/QIWdZZ2Q39limh6+Yxhm/FB1bUpZLA=";
+
+    String wiremockIlpAddress = "test.wiremock";
+    stubFor(get(urlEqualTo("/" + testClient))
+        .withHeader("Accept", equalTo(SpspClient.ACCEPT_SPSP_JSON))
+        .willReturn(aResponse()
+            .withStatus(200)
+            .withBody("{\"destination_account\":\"" + wiremockIlpAddress + "." + testClient + "\","
+                + "\"shared_secret\":\"" + sharedSecret + "\"}")
+        ));
+
+    HttpUrl url = HttpUrl.parse(wireMockRule.baseUrl() + "/" + testClient);
+    StreamConnectionDetails response = client.getStreamConnectionDetails(url);
+
+    assertThat(response)
+        .isEqualTo(StreamConnectionDetails.builder()
+            .destinationAddress(InterledgerAddress.of(wiremockIlpAddress + "." + testClient))
+            .sharedSecret(SharedSecret.of(sharedSecret))
+            .build());
+  }
+
+  @Test(expected = InvalidReceiverClientException.class)
+  public void getStreamConnectionDetails404ThrowsInvalidReceiver() {
+    String testClient = "testClient";
+
+    stubFor(get(urlEqualTo("/" + testClient))
+        .withHeader("Accept", equalTo(SpspClient.ACCEPT_SPSP_JSON))
+        .willReturn(aResponse()
+            .withStatus(404)
+        ));
+
+    client.getStreamConnectionDetails(paymentPointer(testClient));
+  }
+
+  @Test(expected = SpspClientException.class)
+  public void getStreamConnectionDetails500ThrowsSpspClientException() {
+    String testClient = "testClient";
+
+    stubFor(get(urlEqualTo("/" + testClient))
+        .withHeader("Accept", equalTo(SpspClient.ACCEPT_SPSP_JSON))
+        .willReturn(aResponse()
+            .withStatus(503)
+        ));
+
+    client.getStreamConnectionDetails(paymentPointer(testClient));
+  }
+
+  private PaymentPointer paymentPointer(String testClient) {
+    return PaymentPointer.of("$test.wiremock/" + testClient);
+  }
+
+}


### PR DESCRIPTION
Add SPSP client method that takes resolved URL instead of payment pointer. Fixes #381
Create a generic implementation of SPSP client. Fixes #380 
update README with correct. Fixes #379