### PR TITLE
stop using deprecated interledgerrs/node docker image

### DIFF
--- a/stream-parent/stream-client/src/test/java/org/interledger/stream/sender/SimpleStreamSenderIT.java
+++ b/stream-parent/stream-client/src/test/java/org/interledger/stream/sender/SimpleStreamSenderIT.java
@@ -93,7 +93,7 @@ public class SimpleStreamSenderIT {
       .withEnv("REDIS_URL", "redis://redis:6379");
 
   @Rule
-  public GenericContainer interledgerNode = new GenericContainer<>("interledgerrs/node")
+  public GenericContainer interledgerNode = new GenericContainer<>("interledgerrs/ilp-node")
       .withExposedPorts(7770)
       .withNetwork(network)
       //.withLogConsumer(new org.testcontainers.containers.output.Slf4jLogConsumer (logger)) // uncomment to see logs


### PR DESCRIPTION
long live interledgerrs/ilp-node
fixes #384 