### PR TITLE
added a variable and removed an extra space

### DIFF
--- a/link-parent/link-ilp-over-http/src/main/java/org/interledger/link/http/IlpOverHttpConstants.java
+++ b/link-parent/link-ilp-over-http/src/main/java/org/interledger/link/http/IlpOverHttpConstants.java
@@ -12,6 +12,6 @@ public interface IlpOverHttpConstants {
   String OCTET_STREAM_STRING = OCTET_STREAM.toString();
   MediaType APPLICATION_OCTET_STREAM = MediaType.parse(OCTET_STREAM_STRING);
 
-  String BEARER = "Bearer ";
+  String BEARER = "Bearer";
   String ILP_OPERATOR_ADDRESS_VALUE = "ILP-Operator-Address";
 }

--- a/link-parent/link-ilp-over-http/src/main/java/org/interledger/link/http/IlpOverHttpLink.java
+++ b/link-parent/link-ilp-over-http/src/main/java/org/interledger/link/http/IlpOverHttpLink.java
@@ -241,6 +241,7 @@ public class IlpOverHttpLink extends AbstractLink<IlpOverHttpLinkSettings> imple
     }
   }
 
+  private final String BEARER_WITH_SPACE = BEARER + " ";
   /**
    * Construct headers for an ILP-over-HTTP request.
    *
@@ -258,7 +259,7 @@ public class IlpOverHttpLink extends AbstractLink<IlpOverHttpLinkSettings> imple
     // Set the Operator Address header, if present.
     headers.set(IlpOverHttpConstants.ILP_OPERATOR_ADDRESS_VALUE, getOperatorAddressSupplier().get().getValue());
 
-    headers.add(HttpHeaders.AUTHORIZATION, BEARER + this.authTokenSupplier.get());
+    headers.add(HttpHeaders.AUTHORIZATION, BEARER_WITH_SPACE + this.authTokenSupplier.get());
 
     return headers.build();
   }


### PR DESCRIPTION
This fix is for issue #386 

Removed an extra space from variable BEARER in IlpOverHttpConstants file.
Added a variable called BEARER_WITH_SPACE in IlpOverHttpLink file.