### PR TITLE
Add support for in-memory SPSP Receiver (fixes #415)

### DIFF
--- a/link-parent/link-core/src/main/java/org/interledger/link/LoopbackLink.java
+++ b/link-parent/link-core/src/main/java/org/interledger/link/LoopbackLink.java
@@ -53,7 +53,7 @@ public class LoopbackLink extends AbstractLink<LinkSettings> implements Link<Lin
   @Override
   public void registerLinkHandler(LinkHandler ilpDataHandler) throws LinkHandlerAlreadyRegisteredException {
     throw new RuntimeException(
-        "Loopback links never have incoming data, and thus should not have a registered DataHandler."
+        "Loopback links never emit data, and thus should not have a registered DataHandler."
     );
   }
 

--- a/link-parent/link-core/src/main/java/org/interledger/link/PingLoopbackLink.java
+++ b/link-parent/link-core/src/main/java/org/interledger/link/PingLoopbackLink.java
@@ -50,7 +50,7 @@ public class PingLoopbackLink extends AbstractLink<LinkSettings> implements Link
   @Override
   public void registerLinkHandler(LinkHandler ilpDataHandler) throws LinkHandlerAlreadyRegisteredException {
     throw new RuntimeException(
-        "PingLoopback links never have incoming data, and thus should not have a registered DataHandler."
+        "PingLoopback links never emit data, and thus should not have a registered DataHandler."
     );
   }
 

--- a/link-parent/link-core/src/test/java/org/interledger/link/LoopbackLinkTest.java
+++ b/link-parent/link-core/src/test/java/org/interledger/link/LoopbackLinkTest.java
@@ -51,7 +51,7 @@ public class LoopbackLinkTest {
       link.registerLinkHandler(incomingPreparePacket -> null);
     } catch (Exception e) {
       assertThat(e.getMessage())
-          .isEqualTo("Loopback links never have incoming data, and thus should not have a registered DataHandler.");
+          .isEqualTo("Loopback links never emit data, and thus should not have a registered DataHandler.");
       throw e;
     }
   }

--- a/link-parent/link-core/src/test/java/org/interledger/link/PingLoopbackLinkTest.java
+++ b/link-parent/link-core/src/test/java/org/interledger/link/PingLoopbackLinkTest.java
@@ -56,7 +56,7 @@ public class PingLoopbackLinkTest {
       link.registerLinkHandler(incomingPreparePacket -> null);
     } catch (Exception e) {
       assertThat(e.getMessage()).isEqualTo(
-          "PingLoopback links never have incoming data, and thus should not have a registered DataHandler.");
+          "PingLoopback links never emit data, and thus should not have a registered DataHandler.");
       throw e;
     }
   }

--- a/link-parent/link-stateless-spsp-receiver/pom.xml
+++ b/link-parent/link-stateless-spsp-receiver/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.interledger</groupId>
+    <artifactId>link-parent</artifactId>
+    <version>HEAD-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <name>Quilt :: Link :: Stateless SPSP Receiver</name>
+  <artifactId>link-stateless-spsp-receiver</artifactId>
+  <description>A Link implementation for a stateless SPSP receiver.</description>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>codecs-framework</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>ilp-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>link-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>stream-receiver</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.auth0</groupId>
+      <artifactId>java-jwt</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.zalando</groupId>
+      <artifactId>problem</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/link-parent/link-stateless-spsp-receiver/src/main/java/org/interledger/link/spsp/StatelessSpspReceiverLink.java
+++ b/link-parent/link-stateless-spsp-receiver/src/main/java/org/interledger/link/spsp/StatelessSpspReceiverLink.java
@@ -1,0 +1,74 @@
+package org.interledger.link.spsp;
+
+import org.interledger.core.InterledgerAddress;
+import org.interledger.core.InterledgerPreparePacket;
+import org.interledger.core.InterledgerResponsePacket;
+import org.interledger.link.AbstractLink;
+import org.interledger.link.Link;
+import org.interledger.link.LinkHandler;
+import org.interledger.link.LinkType;
+import org.interledger.link.exceptions.LinkHandlerAlreadyRegisteredException;
+import org.interledger.stream.Denomination;
+import org.interledger.stream.receiver.StreamReceiver;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * <p>A {@link Link} that attempts to fulfill packets using an SPSP receiver.</p>
+ */
+public class StatelessSpspReceiverLink extends AbstractLink<StatelessSpspReceiverLinkSettings>
+    implements Link<StatelessSpspReceiverLinkSettings> {
+
+  public static final String LINK_TYPE_STRING = "STATELESS_SPSP_RECEIVER";
+  public static final LinkType LINK_TYPE = LinkType.of(LINK_TYPE_STRING);
+
+  private final StreamReceiver streamReceiver;
+  private final Denomination denomination;
+
+  /**
+   * Required-Args Constructor.
+   *
+   * @param operatorAddressSupplier A supplier for the ILP address of this node operating this Link. This value may be
+   *                                uninitialized, for example, in cases where the Link obtains its address from a
+   *                                parent node using IL-DCP. If an ILP address has not been assigned, or it has not
+   *                                been obtained via IL-DCP, then this value will by default be {@link Link#SELF}.
+   * @param linkSettings            A {@link StatelessSpspReceiverLinkSettings} for this Link.
+   * @param streamReceiver          A {@link StreamReceiver} that can fulfill packets.
+   */
+  public StatelessSpspReceiverLink(
+      final Supplier<InterledgerAddress> operatorAddressSupplier,
+      final StatelessSpspReceiverLinkSettings linkSettings,
+      final StreamReceiver streamReceiver
+  ) {
+    super(operatorAddressSupplier, linkSettings);
+    this.denomination = Denomination.builder()
+        .assetCode(linkSettings.assetCode())
+        .assetScale(linkSettings.assetScale())
+        .build();
+    this.streamReceiver = Objects.requireNonNull(streamReceiver);
+  }
+
+  @Override
+  public void registerLinkHandler(final LinkHandler ilpDataHandler) throws LinkHandlerAlreadyRegisteredException {
+    throw new RuntimeException(
+        "StatelessSpspReceiver links never emit data, and thus should not have a registered DataHandler."
+    );
+  }
+
+  @Override
+  public InterledgerResponsePacket sendPacket(final InterledgerPreparePacket preparePacket) {
+    Objects.requireNonNull(preparePacket, "preparePacket must not be null");
+
+    return streamReceiver.receiveMoney(preparePacket, this.getOperatorAddressSupplier().get(), this.denomination)
+        .map(fulfillPacket -> {
+              logger.info("Packet fulfilled! preparePacket={} fulfillPacket={}", preparePacket, fulfillPacket);
+              return fulfillPacket;
+            },
+            rejectPacket -> {
+              logger.info("Packet rejected! preparePacket={} rejectPacket={}", preparePacket, rejectPacket);
+              return rejectPacket;
+            }
+        );
+  }
+}

--- a/link-parent/link-stateless-spsp-receiver/src/main/java/org/interledger/link/spsp/StatelessSpspReceiverLinkFactory.java
+++ b/link-parent/link-stateless-spsp-receiver/src/main/java/org/interledger/link/spsp/StatelessSpspReceiverLinkFactory.java
@@ -6,7 +6,6 @@ import org.interledger.link.LinkFactory;
 import org.interledger.link.LinkId;
 import org.interledger.link.LinkSettings;
 import org.interledger.link.LinkType;
-import org.interledger.link.LoopbackLink;
 import org.interledger.link.PacketRejector;
 import org.interledger.link.exceptions.LinkException;
 import org.interledger.stream.receiver.StatelessStreamReceiver;
@@ -15,7 +14,7 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 /**
- * An implementation of {@link LinkFactory} for creating Links that can handle the `Loopback` packets.
+ * An implementation of {@link LinkFactory} for constructing instances of {@link StatelessSpspReceiverLink}.
  */
 public class StatelessSpspReceiverLinkFactory implements LinkFactory {
 

--- a/link-parent/link-stateless-spsp-receiver/src/main/java/org/interledger/link/spsp/StatelessSpspReceiverLinkFactory.java
+++ b/link-parent/link-stateless-spsp-receiver/src/main/java/org/interledger/link/spsp/StatelessSpspReceiverLinkFactory.java
@@ -1,0 +1,82 @@
+package org.interledger.link.spsp;
+
+import org.interledger.core.InterledgerAddress;
+import org.interledger.link.Link;
+import org.interledger.link.LinkFactory;
+import org.interledger.link.LinkId;
+import org.interledger.link.LinkSettings;
+import org.interledger.link.LinkType;
+import org.interledger.link.LoopbackLink;
+import org.interledger.link.PacketRejector;
+import org.interledger.link.exceptions.LinkException;
+import org.interledger.stream.receiver.StatelessStreamReceiver;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * An implementation of {@link LinkFactory} for creating Links that can handle the `Loopback` packets.
+ */
+public class StatelessSpspReceiverLinkFactory implements LinkFactory {
+
+  private final PacketRejector packetRejector;
+  private final StatelessStreamReceiver statelessStreamReceiver;
+
+  /**
+   * Required-args Constructor.
+   *
+   * @param packetRejector          An instance of {@link PacketRejector}.
+   * @param statelessStreamReceiver A {@link StatelessStreamReceiver} for encrypting/decrypting STREAM packets.
+   */
+  public StatelessSpspReceiverLinkFactory(
+      final PacketRejector packetRejector, final StatelessStreamReceiver statelessStreamReceiver
+  ) {
+    this.packetRejector = Objects.requireNonNull(packetRejector, "packetRejector must not be null");
+    this.statelessStreamReceiver = Objects
+        .requireNonNull(statelessStreamReceiver, "statelessStreamReceiver must not be null");
+  }
+
+  /**
+   * An abstract method that sub-classes must implemented to provide actual factory functionality.
+   *
+   * @param operatorAddressSupplier A supplier for the ILP address of this node operating this Link. This value may be
+   *                                uninitialized, for example, in cases where the Link obtains its address from a
+   *                                parent node using IL-DCP. If an ILP address has not been assigned, or it has not
+   *                                been obtained via IL-DCP, then this value will by default be {@link Link#SELF}.
+   * @param linkSettings            An instance of {@link LinkSettings} to initialize this link from.
+   *
+   * @return A newly constructed instance of {@link Link}.
+   */
+  @Override
+  public Link<?> constructLink(
+      final Supplier<InterledgerAddress> operatorAddressSupplier, final LinkSettings linkSettings
+  ) {
+    Objects.requireNonNull(operatorAddressSupplier, "operatorAddressSupplier must not be null");
+    Objects.requireNonNull(linkSettings, "linkSettings must not be null");
+
+    if (!this.supports(linkSettings.getLinkType())) {
+      throw new LinkException(
+          String.format("LinkType not supported by this factory. linkType=%s", linkSettings.getLinkType()),
+          LinkId.of("n/a")
+      );
+    }
+
+    // Translate from Link.customSettings, being sure to apply custom settings from the incoming link.
+    final ImmutableStatelessSpspReceiverLinkSettings.Builder builder = StatelessSpspReceiverLinkSettings
+        .builder()
+        .from(linkSettings);
+
+    final StatelessSpspReceiverLinkSettings statelessSpspReceiverLinkSettings =
+        StatelessSpspReceiverLinkSettings.applyCustomSettings(builder, linkSettings.getCustomSettings()).build();
+
+    return new StatelessSpspReceiverLink(
+        operatorAddressSupplier, statelessSpspReceiverLinkSettings, statelessStreamReceiver
+    );
+  }
+
+  @Override
+  public boolean supports(LinkType linkType) {
+    return StatelessSpspReceiverLink.LINK_TYPE.equals(linkType);
+  }
+
+}

--- a/link-parent/link-stateless-spsp-receiver/src/main/java/org/interledger/link/spsp/StatelessSpspReceiverLinkSettings.java
+++ b/link-parent/link-stateless-spsp-receiver/src/main/java/org/interledger/link/spsp/StatelessSpspReceiverLinkSettings.java
@@ -1,0 +1,106 @@
+package org.interledger.link.spsp;
+
+import org.interledger.link.LinkId;
+import org.interledger.link.LinkSettings;
+import org.interledger.link.LinkType;
+import org.interledger.link.exceptions.LinkException;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Derived;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * An extension of {@link LinkSettings} for ILP-over-HTTP links.
+ */
+public interface StatelessSpspReceiverLinkSettings extends LinkSettings {
+
+  String ASSET_CODE = "assetCode";
+  String ASSET_SCALE = "assetScale";
+
+  static ImmutableStatelessSpspReceiverLinkSettings.Builder builder() {
+    return ImmutableStatelessSpspReceiverLinkSettings.builder();
+  }
+
+  /**
+   * Constructs a new builder with the correct custom settings, as found in {@code customSettings}.
+   *
+   * @param customSettings A {@link Map} of custom settings.
+   *
+   * @return A {@link ImmutableStatelessSpspReceiverLinkSettings.Builder}.
+   */
+  static ImmutableStatelessSpspReceiverLinkSettings.Builder fromCustomSettings(
+      final Map<String, Object> customSettings
+  ) {
+    Objects.requireNonNull(customSettings);
+    return applyCustomSettings(StatelessSpspReceiverLinkSettings.builder(), customSettings);
+  }
+
+  /**
+   * Populate a supplied builder with the correct custom settings, as found in {@code customSettings}.
+   *
+   * @param builder        A {@link ImmutableStatelessSpspReceiverLinkSettings.Builder} to update with custom settings.
+   * @param customSettings A {@link Map} of custom settings.
+   *
+   * @return A {@link ImmutableStatelessSpspReceiverLinkSettings.Builder}.
+   */
+  static ImmutableStatelessSpspReceiverLinkSettings.Builder applyCustomSettings(
+      final ImmutableStatelessSpspReceiverLinkSettings.Builder builder, Map<String, Object> customSettings
+  ) {
+    Objects.requireNonNull(builder);
+    Objects.requireNonNull(customSettings);
+
+    Optional.ofNullable(customSettings.get(ASSET_CODE))
+        .map(Object::toString)
+        .map(builder::assetCode)
+        .orElseThrow(() -> new LinkException(
+            "assetCode is required to construct a Link of type " + StatelessSpspReceiverLink.LINK_TYPE,
+            LinkId.of("n/a"))
+        );
+
+    Optional.ofNullable(customSettings.get(ASSET_SCALE))
+        .map(Object::toString)
+        .map(Short::parseShort)
+        .map(builder::assetScale)
+        .orElseThrow(() -> new LinkException(
+            "assetScale is required to construct a Link of type " + StatelessSpspReceiverLink.LINK_TYPE,
+            LinkId.of("n/a"))
+        );
+
+    builder.customSettings(customSettings);
+
+    return builder;
+  }
+
+  @Override
+  default LinkType getLinkType() {
+    return StatelessSpspReceiverLink.LINK_TYPE;
+  }
+
+  /**
+   * Currency code or other asset identifier that will be used to select the correct rate for this account.
+   */
+  String assetCode();
+
+  /**
+   * Interledger amounts are integers, but most currencies are typically represented as # fractional units, e.g. cents.
+   * This property defines how many Interledger units make # up one regular unit. For dollars, this would usually be set
+   * to 9, so that Interledger # amounts are expressed in nano-dollars.
+   *
+   * @return an int representing this account's asset scale.
+   */
+  short assetScale();
+
+  @Value.Immutable
+  abstract class AbstractStatelessSpspReceiverLinkSettings implements StatelessSpspReceiverLinkSettings {
+
+    @Derived
+    @Override
+    public LinkType getLinkType() {
+      return StatelessSpspReceiverLink.LINK_TYPE;
+    }
+
+  }
+}

--- a/link-parent/link-stateless-spsp-receiver/src/main/java/org/interledger/link/spsp/StatelessSpspReceiverLinkSettings.java
+++ b/link-parent/link-stateless-spsp-receiver/src/main/java/org/interledger/link/spsp/StatelessSpspReceiverLinkSettings.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * An extension of {@link LinkSettings} for ILP-over-HTTP links.
+ * An extension of {@link LinkSettings} for Stateless SPSP receiver links.
  */
 public interface StatelessSpspReceiverLinkSettings extends LinkSettings {
 

--- a/link-parent/link-stateless-spsp-receiver/src/test/java/org/interledger/link/spsp/StatelessSpspReceiverLinkFactoryTest.java
+++ b/link-parent/link-stateless-spsp-receiver/src/test/java/org/interledger/link/spsp/StatelessSpspReceiverLinkFactoryTest.java
@@ -1,0 +1,152 @@
+package org.interledger.link.spsp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.interledger.link.spsp.StatelessSpspReceiverLinkSettings.ASSET_CODE;
+import static org.interledger.link.spsp.StatelessSpspReceiverLinkSettings.ASSET_SCALE;
+
+import org.interledger.core.InterledgerAddress;
+import org.interledger.link.Link;
+import org.interledger.link.LinkId;
+import org.interledger.link.LinkSettings;
+import org.interledger.link.LinkType;
+import org.interledger.link.PacketRejector;
+import org.interledger.link.exceptions.LinkException;
+import org.interledger.stream.receiver.StatelessStreamReceiver;
+
+import com.google.common.collect.Maps;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Map;
+
+/**
+ * Unit tests for {@link StatelessSpspReceiverLinkFactory}.
+ */
+public class StatelessSpspReceiverLinkFactoryTest {
+
+  private static final InterledgerAddress OPERATOR_ADDRESS = InterledgerAddress.of("test.operator");
+  private final LinkId linkId = LinkId.of("foo");
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Mock
+  private LinkSettings linkSettingsMock;
+
+  @Mock
+  private PacketRejector packetRejectorMock;
+
+  @Mock
+  private StatelessStreamReceiver statelessStreamReceiverMock;
+
+  private StatelessSpspReceiverLinkFactory statelessSpspReceiverLinkFactory;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    this.statelessSpspReceiverLinkFactory = new StatelessSpspReceiverLinkFactory(
+        packetRejectorMock, statelessStreamReceiverMock
+    );
+  }
+
+  @Test
+  public void constructWithNulPacketRejector() {
+    expectedException.expect(NullPointerException.class);
+    expectedException.expectMessage("packetRejector must not be null");
+
+    new StatelessSpspReceiverLinkFactory(null, statelessStreamReceiverMock);
+  }
+
+  @Test
+  public void constructWithNulStatelessStreamReceiver() {
+    expectedException.expect(NullPointerException.class);
+    expectedException.expectMessage("statelessStreamReceiver must not be null");
+
+    new StatelessSpspReceiverLinkFactory(packetRejectorMock, null);
+  }
+
+  @Test
+  public void supports() {
+    assertThat(statelessSpspReceiverLinkFactory.supports(StatelessSpspReceiverLink.LINK_TYPE)).isEqualTo(true);
+    assertThat(statelessSpspReceiverLinkFactory.supports(LinkType.of("foo"))).isEqualTo(false);
+  }
+
+  @Test
+  public void constructLinkWithNullOperator() {
+    expectedException.expect(NullPointerException.class);
+    expectedException.expectMessage("operatorAddressSupplier must not be null");
+
+    statelessSpspReceiverLinkFactory.constructLink(null, linkSettingsMock);
+  }
+
+  @Test
+  public void constructLinkWithNullLinkSettings() {
+    expectedException.expect(NullPointerException.class);
+    expectedException.expectMessage("linkSettings must not be null");
+
+    statelessSpspReceiverLinkFactory.constructLink(() -> OPERATOR_ADDRESS, null);
+  }
+
+  @Test
+  public void constructLinkWithUnsupportedLinkType() {
+    expectedException.expect(LinkException.class);
+    expectedException.expectMessage("LinkType not supported by this factory. linkType=LinkType(FOO)");
+
+    LinkSettings linkSettings = LinkSettings.builder()
+        .linkType(LinkType.of("foo"))
+        .build();
+    statelessSpspReceiverLinkFactory.constructLink(() -> OPERATOR_ADDRESS, linkSettings);
+  }
+
+  @Test
+  public void constructLinkWithMissingAssetCode() {
+    expectedException.expect(LinkException.class);
+    expectedException
+        .expectMessage("assetCode is required to construct a Link of type LinkType(STATELESS_SPSP_RECEIVER)");
+
+    final Map<String, Object> customSettings = Maps.newHashMap();
+    customSettings.put(ASSET_SCALE, "9");
+    LinkSettings linkSettings = LinkSettings.builder()
+        .linkType(StatelessSpspReceiverLink.LINK_TYPE)
+        .customSettings(customSettings)
+        .build();
+    Link<?> link = statelessSpspReceiverLinkFactory.constructLink(() -> OPERATOR_ADDRESS, linkSettings);
+    link.setLinkId(linkId);
+    assertThat(link.getLinkId()).isEqualTo(linkId);
+  }
+
+  @Test
+  public void constructLinkWithMissingAssetScale() {
+    expectedException.expect(LinkException.class);
+    expectedException
+        .expectMessage("assetScale is required to construct a Link of type LinkType(STATELESS_SPSP_RECEIVER)");
+
+    final Map<String, Object> customSettings = Maps.newHashMap();
+    customSettings.put(ASSET_CODE, "USD");
+    LinkSettings linkSettings = LinkSettings.builder()
+        .linkType(StatelessSpspReceiverLink.LINK_TYPE)
+        .customSettings(customSettings)
+        .build();
+    Link<?> link = statelessSpspReceiverLinkFactory.constructLink(() -> OPERATOR_ADDRESS, linkSettings);
+    link.setLinkId(linkId);
+    assertThat(link.getLinkId()).isEqualTo(linkId);
+  }
+
+  @Test
+  public void constructLink() {
+    final Map<String, Object> customSettings = Maps.newHashMap();
+    customSettings.put(ASSET_CODE, "USD");
+    customSettings.put(ASSET_SCALE, "9");
+    LinkSettings linkSettings = LinkSettings.builder()
+        .linkType(StatelessSpspReceiverLink.LINK_TYPE)
+        .customSettings(customSettings)
+        .build();
+    Link<?> link = statelessSpspReceiverLinkFactory.constructLink(() -> OPERATOR_ADDRESS, linkSettings);
+    link.setLinkId(linkId);
+    assertThat(link.getLinkId()).isEqualTo(linkId);
+  }
+}

--- a/link-parent/link-stateless-spsp-receiver/src/test/java/org/interledger/link/spsp/StatelessSpspReceiverLinkTest.java
+++ b/link-parent/link-stateless-spsp-receiver/src/test/java/org/interledger/link/spsp/StatelessSpspReceiverLinkTest.java
@@ -1,0 +1,105 @@
+package org.interledger.link.spsp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.interledger.core.InterledgerConstants.ALL_ZEROS_FULFILLMENT;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import org.interledger.core.DateUtils;
+import org.interledger.core.InterledgerAddress;
+import org.interledger.core.InterledgerConstants;
+import org.interledger.core.InterledgerFulfillPacket;
+import org.interledger.core.InterledgerPreparePacket;
+import org.interledger.link.LinkId;
+import org.interledger.stream.receiver.StreamReceiver;
+
+import com.google.common.primitives.UnsignedLong;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Unit tests for {@link StatelessSpspReceiverLink}.
+ */
+public class StatelessSpspReceiverLinkTest {
+
+  private static final InterledgerAddress OPERATOR_ADDRESS = InterledgerAddress.of("test.foo");
+
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Mock
+  private StreamReceiver streamReceiverMock;
+
+  private StatelessSpspReceiverLink link;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    this.link = new StatelessSpspReceiverLink(
+        () -> OPERATOR_ADDRESS,
+        StatelessSpspReceiverLinkSettings.builder().assetCode("XRP").assetScale((short) 9).build(),
+        streamReceiverMock
+    );
+    link.setLinkId(LinkId.of("foo"));
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void registerLinkHandler() {
+    try {
+      link.registerLinkHandler(incomingPreparePacket -> null);
+    } catch (Exception e) {
+      assertThat(e.getMessage())
+          .isEqualTo("StatelessSpspReceiver links never emit data, and thus should not have a registered DataHandler.");
+      throw e;
+    }
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void sendPacketWithNull() {
+    try {
+      link.sendPacket(null);
+    } catch (NullPointerException e) {
+      assertThat(e.getMessage()).isEqualTo("preparePacket must not be null");
+      throw e;
+    }
+  }
+
+  @Test
+  public void sendPacket() {
+    final InterledgerFulfillPacket actualFulfillPacket = InterledgerFulfillPacket.builder()
+        .fulfillment(ALL_ZEROS_FULFILLMENT)
+        .build();
+    when(streamReceiverMock.receiveMoney(any(), any(), any())).thenReturn(actualFulfillPacket);
+
+    final InterledgerPreparePacket preparePacket = preparePacket();
+    link.sendPacket(preparePacket).handle(
+        fulfillPacket -> {
+          assertThat(fulfillPacket).isEqualTo(actualFulfillPacket);
+        },
+        rejectPacket -> {
+          logger.error("rejectPacket={}", rejectPacket);
+          fail("Expected a Fulfill");
+        }
+    );
+  }
+
+  private InterledgerPreparePacket preparePacket() {
+    return InterledgerPreparePacket.builder()
+        .amount(UnsignedLong.valueOf(10L))
+        .executionCondition(InterledgerConstants.ALL_ZEROS_CONDITION)
+        .destination(OPERATOR_ADDRESS)
+        .expiresAt(DateUtils.now())
+        .data(new byte[32])
+        .build();
+  }
+}

--- a/link-parent/pom.xml
+++ b/link-parent/pom.xml
@@ -16,6 +16,7 @@
   <modules>
     <module>link-core</module>
     <module>link-ilp-over-http</module>
+    <module>link-stateless-spsp-receiver</module>
   </modules>
 
 </project>


### PR DESCRIPTION
Add support for an in-memory Stateless Stream Receiver Link. This enables a Connector to fulfill ILP packets without having to forward to an actual SPSP Receiver server.

Signed-off-by: David Fuelling <sappenin@gmail.com>