### PR TITLE
Make `WELL_KNOWN` constant public

### DIFF
--- a/spsp-parent/spsp-core/src/main/java/org/interledger/spsp/PaymentPointer.java
+++ b/spsp-parent/spsp-core/src/main/java/org/interledger/spsp/PaymentPointer.java
@@ -61,7 +61,7 @@ public interface PaymentPointer {
   @Immutable
   abstract class AbstractPaymentPointer implements PaymentPointer {
 
-    private static final String WELL_KNOWN = "/.well-known/pay";
+    public static final String WELL_KNOWN = "/.well-known/pay";
 
     @Default
     public String path() {

--- a/spsp-parent/spsp-core/src/main/java/org/interledger/spsp/PaymentPointer.java
+++ b/spsp-parent/spsp-core/src/main/java/org/interledger/spsp/PaymentPointer.java
@@ -14,6 +14,8 @@ import org.immutables.value.Value.Immutable;
  */
 public interface PaymentPointer {
 
+  public static final String WELL_KNOWN = "/.well-known/pay";
+  
   /**
    * Parses a payment pointer string into a @{code PaymentPointer}.
    * @param value text
@@ -60,9 +62,6 @@ public interface PaymentPointer {
 
   @Immutable
   abstract class AbstractPaymentPointer implements PaymentPointer {
-
-    public static final String WELL_KNOWN = "/.well-known/pay";
-
     @Default
     public String path() {
       return WELL_KNOWN;

--- a/spsp-parent/spsp-core/src/test/java/org/interledger/spsp/PaymentPointerTest.java
+++ b/spsp-parent/spsp-core/src/test/java/org/interledger/spsp/PaymentPointerTest.java
@@ -20,25 +20,25 @@ public class PaymentPointerTest {
   @Test
   public void wellKnownPath() {
     assertThat(PaymentPointer.of("$example.com").path())
-        .isEqualTo("/.well-known/pay");
+        .isEqualTo(PaymentPointer.WELL_KNOWN);
   }
 
   @Test
   public void wellKnownPathWithTrailingSlash() {
     assertThat(PaymentPointer.of("$example.com/").path())
-        .isEqualTo("/.well-known/pay");
+        .isEqualTo(PaymentPointer.WELL_KNOWN);
   }
 
   @Test
   public void builderWithWellKnownPathWithTrailingSlash() {
     assertThat(ImmutablePaymentPointer.builder().host("example.com").path("/").build().path())
-        .isEqualTo("/.well-known/pay");
+        .isEqualTo(PaymentPointer.WELL_KNOWN);
   }
 
   @Test
   public void builderWithWellKnownPathWithoutTrailingSlash() {
     assertThat(ImmutablePaymentPointer.builder().host("example.com").path("").build().path())
-        .isEqualTo("/.well-known/pay");
+        .isEqualTo(PaymentPointer.WELL_KNOWN);
   }
 
   @Test


### PR DESCRIPTION
I'd like to make WELL_KNOWN a public constant. This is useful because it means that there is a source of truth for this value. 

In practice, this improves our test code because we no longer have to hard code this magic constant. 