### PR TITLE
Validate failure on invalid STREAM frames

### DIFF
--- a/codecs-parent/codecs-framework/src/main/java/org/interledger/encoding/asn/codecs/AsnSequenceCodec.java
+++ b/codecs-parent/codecs-framework/src/main/java/org/interledger/encoding/asn/codecs/AsnSequenceCodec.java
@@ -9,9 +9,9 @@ package org.interledger.encoding.asn.codecs;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,27 +22,30 @@ package org.interledger.encoding.asn.codecs;
 
 import org.interledger.encoding.asn.framework.AsnObjectCodec;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
- * ASN.1 object codec that represents a {@link List} of other ASN.1 codecs to encode/decode an
- * ASN.1 SEQUENCE
+ * ASN.1 object codec that represents a {@link List} of other ASN.1 codecs to encode/decode an ASN.1 SEQUENCE
  *
  * <p>This base class should be used for codecs where the ASN.1 object is a subclass of an ASN.1
  * SEQUENCE.
  *
  * <p>Codecs that extend this object can call {@link #getValueAt(int)} and
- * {@link #setValueAt(int, Object)} in their implementations of {@link #decode()} and
- * {@link #encode(Object)} respectively.
+ * {@link #setValueAt(int, Object)} in their implementations of {@link #decode()} and {@link #encode(Object)}
+ * respectively.
  *
  * <p>Codecs that extend this object can also call {@link #getCodecAt(int)} and
  * {@link #setCodecAt(int, AsnObjectCodec)} to access the internal codecs for each field.
- *
  */
 public abstract class AsnSequenceCodec<T> extends AsnObjectCodecBase<T> {
+
+  protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   private final List<AsnObjectCodec> sequence;
 
@@ -69,11 +72,11 @@ public abstract class AsnSequenceCodec<T> extends AsnObjectCodecBase<T> {
    *
    * <p>Implementations can use this function to dynamically set the codecs for a field that has not
    * yet been encoded (usually as a result of the value encoded into another field).
-
-   * @see AsnObjectCodecBase#setValueChangedEventListener(Consumer)
    *
    * @param index Index of the field in the sequence.
    * @param codec Codec to use of encoding/decoding the field.
+   *
+   * @see AsnObjectCodecBase#setValueChangedEventListener(Consumer)
    */
   protected void setCodecAt(int index, AsnObjectCodec codec) {
     Objects.requireNonNull(codec);
@@ -84,8 +87,9 @@ public abstract class AsnSequenceCodec<T> extends AsnObjectCodecBase<T> {
    * Get and decoded the value from the codec at the given index.
    *
    * @param index the index of the field that is being decoded
-   * @param <U> the type of the codec at the given index
-   * @param <V> the type of the value that will be decoded
+   * @param <U>   the type of the codec at the given index
+   * @param <V>   the type of the value that will be decoded
+   *
    * @return the decoded filed value
    */
   public final <U extends AsnObjectCodecBase<V>, V> V getValueAt(int index) {
@@ -97,8 +101,8 @@ public abstract class AsnSequenceCodec<T> extends AsnObjectCodecBase<T> {
    *
    * @param index the index of the field that is being encoded.
    * @param value the value of the field that is being encoded.
-   * @param <U> the type of the codec at the given index.
-   * @param <V> the type of the value that will be encoded.
+   * @param <U>   the type of the codec at the given index.
+   * @param <V>   the type of the value that will be encoded.
    */
   public final <U extends AsnObjectCodecBase<V>, V> void setValueAt(int index, V value) {
     ((U) getCodecAt(index)).encode(value);
@@ -109,6 +113,7 @@ public abstract class AsnSequenceCodec<T> extends AsnObjectCodecBase<T> {
    * Get the codec for the field at the specified index.
    *
    * @param index index of the field
+   *
    * @return the codec for the field at the specified index
    */
   public AsnObjectCodec getCodecAt(int index) {
@@ -138,9 +143,14 @@ public abstract class AsnSequenceCodec<T> extends AsnObjectCodecBase<T> {
 
   @Override
   public String toString() {
-    return "AsnSequenceCodec{"
-        + "sequence="
-        + Arrays.toString(sequence.toArray())
-        + '}';
+    try {
+      return this.getClass().getName() + "{"
+          + "sequence="
+          + Arrays.toString(sequence.toArray())
+          + '}';
+    } catch (Exception e) {
+      logger.warn(e.getMessage(), e);
+      return this.getClass().getName() + "{ ... (unable to display values) ... }";
+    }
   }
 }

--- a/codecs-parent/codecs-framework/src/main/java/org/interledger/encoding/asn/codecs/AsnSequenceOfSequenceCodec.java
+++ b/codecs-parent/codecs-framework/src/main/java/org/interledger/encoding/asn/codecs/AsnSequenceOfSequenceCodec.java
@@ -20,9 +20,6 @@ package org.interledger.encoding.asn.codecs;
  * =========================LICENSE_END==================================
  */
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -38,8 +35,6 @@ import java.util.function.Supplier;
  * @see "https://www.oss.com/asn1/resources/books-whitepapers-pubs/Overview_of_OER.pdf"
  */
 public class AsnSequenceOfSequenceCodec<L extends List<T>, T> extends AsnObjectCodecBase<L> {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(AsnSequenceOfSequenceCodec.class);
 
   private static final int CODECS_ARRAY_INITIAL_CAPACITY = 5;
 

--- a/codecs-parent/codecs-framework/src/main/java/org/interledger/encoding/asn/codecs/AsnSequenceOfSequenceCodec.java
+++ b/codecs-parent/codecs-framework/src/main/java/org/interledger/encoding/asn/codecs/AsnSequenceOfSequenceCodec.java
@@ -133,11 +133,7 @@ public class AsnSequenceOfSequenceCodec<L extends List<T>, T> extends AsnObjectC
     Objects.requireNonNull(codecs);
     L list = listConstructor.get();
     for (AsnSequenceCodec<T> codec : codecs) {
-      try {
-        list.add(codec.decode());
-      } catch (Exception e) {
-        LOGGER.warn("Skipping invalid STREAM Frame: {}", e.getMessage(), e);
-      }
+      list.add(codec.decode());
     }
     return list;
   }

--- a/codecs-parent/codecs-framework/src/main/java/org/interledger/encoding/asn/codecs/AsnSequenceOfSequenceCodec.java
+++ b/codecs-parent/codecs-framework/src/main/java/org/interledger/encoding/asn/codecs/AsnSequenceOfSequenceCodec.java
@@ -20,6 +20,9 @@ package org.interledger.encoding.asn.codecs;
  * =========================LICENSE_END==================================
  */
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -35,6 +38,8 @@ import java.util.function.Supplier;
  * @see "https://www.oss.com/asn1/resources/books-whitepapers-pubs/Overview_of_OER.pdf"
  */
 public class AsnSequenceOfSequenceCodec<L extends List<T>, T> extends AsnObjectCodecBase<L> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AsnSequenceOfSequenceCodec.class);
 
   private static final int CODECS_ARRAY_INITIAL_CAPACITY = 5;
 
@@ -128,7 +133,11 @@ public class AsnSequenceOfSequenceCodec<L extends List<T>, T> extends AsnObjectC
     Objects.requireNonNull(codecs);
     L list = listConstructor.get();
     for (AsnSequenceCodec<T> codec : codecs) {
-      list.add(codec.decode());
+      try {
+        list.add(codec.decode());
+      } catch (Exception e) {
+        LOGGER.warn("Skipping invalid STREAM Frame: {}", e.getMessage(), e);
+      }
     }
     return list;
   }


### PR DESCRIPTION
If a particular frame in a StreamPacket cannot be decoded for whatever reason, we should not swallow exception. See comments in unit test code for rationale.

Fixes #455

Signed-off-by: David Fuelling <sappenin@gmail.com>