### PR TITLE
Use cached thread-pool instead of unbounded pool

### DIFF
--- a/stream-parent/stream-client/src/main/java/org/interledger/stream/sender/SimpleStreamSender.java
+++ b/stream-parent/stream-client/src/main/java/org/interledger/stream/sender/SimpleStreamSender.java
@@ -179,7 +179,7 @@ public class SimpleStreamSender implements StreamSender {
         .setDaemon(true)
         .setNameFormat("simple-stream-sender-%d")
         .build();
-    return Executors.newFixedThreadPool(30, factory);
+    return Executors.newCachedThreadPool(factory);
   }
 
   @Override


### PR DESCRIPTION
Using Executors.newFixedThreadPool will start off with 30 threads, but will create new threads in an unbounded fashion. Instead, using the cachedThreadPool this behavior will find a steady-state.

Signed-off-by: David Fuelling <sappenin@gmail.com>