### PR TITLE
Add typeData field to InterledgerPacket

### DIFF
--- a/examples-parent/ilp-emitters/src/main/java/org/interledger/examples/packets/IlpPacketEmitter.java
+++ b/examples-parent/ilp-emitters/src/main/java/org/interledger/examples/packets/IlpPacketEmitter.java
@@ -132,6 +132,7 @@ public class IlpPacketEmitter {
     return InterledgerFulfillPacket.builder()
         .fulfillment(InterledgerFulfillment.of(new byte[32]))
         .data(streamPacketData)
+        .typedData(streamPacket)
         .build();
   }
 
@@ -172,7 +173,8 @@ public class IlpPacketEmitter {
         .getCondition();
     return preparePacketBuilder()
         .executionCondition(executionCondition)
-        .data(streamPacketData);
+        .data(streamPacketData)
+        .typedData(streamPacket);
   }
 
   private static InterledgerRejectPacket rejectPacketWithStreamFrames() throws IOException {

--- a/ildcp-core/src/main/java/org/interledger/ildcp/IldcpRequestPacket.java
+++ b/ildcp-core/src/main/java/org/interledger/ildcp/IldcpRequestPacket.java
@@ -32,6 +32,7 @@ import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Derived;
 
 import java.time.Instant;
+import java.util.Optional;
 
 /**
  * An extension of {@link InterledgerPreparePacket} that can be used as an IL-DCP request over Interledger.
@@ -62,9 +63,8 @@ public interface IldcpRequestPacket extends InterledgerPreparePacket {
   }
 
   /**
-   * The execution_condition of an ILP packet for IL-DCP is always
-   * {@code Zmh6rfhivXdsj8GLjp+OIAiXFIVu4jOzkCpZHQ1fKSU=} in Base64 format, which is the SHA-256 hash of a 32-byte
-   * array with all 0 values.
+   * The execution_condition of an ILP packet for IL-DCP is always {@code Zmh6rfhivXdsj8GLjp+OIAiXFIVu4jOzkCpZHQ1fKSU=}
+   * in Base64 format, which is the SHA-256 hash of a 32-byte array with all 0 values.
    */
   @Override
   default InterledgerCondition getExecutionCondition() {
@@ -96,6 +96,11 @@ public interface IldcpRequestPacket extends InterledgerPreparePacket {
   @Override
   default byte[] getData() {
     return EMPTY_DATA;
+  }
+
+  @Override
+  default Optional<Object> typedData() {
+    return Optional.empty();
   }
 
   /**

--- a/ildcp-core/src/main/java/org/interledger/ildcp/IldcpResponsePacket.java
+++ b/ildcp-core/src/main/java/org/interledger/ildcp/IldcpResponsePacket.java
@@ -9,9 +9,9 @@ package org.interledger.ildcp;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,6 +25,8 @@ import org.interledger.core.InterledgerFulfillPacket;
 import org.interledger.core.InterledgerFulfillment;
 
 import org.immutables.value.Value.Default;
+
+import java.util.Optional;
 
 /**
  * An extension of {@link InterledgerFulfillPacket} that is also a {@link IldcpResponsePacket} that can be used as an
@@ -51,6 +53,11 @@ public interface IldcpResponsePacket extends InterledgerFulfillPacket {
    * @return The {@link IldcpResponse}.
    */
   IldcpResponse getIldcpResponse();
+
+  @Override
+  default Optional<Object> typedData() {
+    return Optional.empty();
+  }
 
   /**
    * Exists to satisfy Immutables.

--- a/ilp-core/src/main/java/org/interledger/core/InterledgerPacket.java
+++ b/ilp-core/src/main/java/org/interledger/core/InterledgerPacket.java
@@ -20,6 +20,8 @@ package org.interledger.core;
  * =========================LICENSE_END==================================
  */
 
+import java.util.Optional;
+
 public interface InterledgerPacket {
 
   /**
@@ -29,4 +31,12 @@ public interface InterledgerPacket {
    * @return A byte array.
    */
   byte[] getData();
+
+  /**
+   * Typed variant of {@link #getData}. This method exists so that implementations can constructed object (e.g., a
+   * StreamPacket) and use them in various places in code without having to decode this object's bytes more than once.
+   *
+   * @return An optionally-present {@link Object} that can be cast to an appropriate type.
+   */
+  Optional<Object> typedData();
 }

--- a/stream-parent/stream-client/src/main/java/org/interledger/stream/sender/SimpleStreamSender.java
+++ b/stream-parent/stream-client/src/main/java/org/interledger/stream/sender/SimpleStreamSender.java
@@ -494,6 +494,7 @@ public class SimpleStreamSender implements StreamSender {
           .executionCondition(executionCondition)
           .expiresAt(DateUtils.now().plusSeconds(30L))
           .data(streamPacketData)
+          .typedData(streamPacket)
           .build();
 
       // The function that parses out the STREAM packets...
@@ -604,6 +605,8 @@ public class SimpleStreamSender implements StreamSender {
             .executionCondition(executionCondition)
             .expiresAt(DateUtils.now().plusSeconds(30L))
             .data(streamPacketData)
+            // Added here for JVM convenience, but only the bytes above are encoded to ASN.1 OER
+            .typedData(streamPacket)
             .build();
 
         // auth

--- a/stream-parent/stream-receiver/src/main/java/org/interledger/stream/receiver/StatelessStreamReceiver.java
+++ b/stream-parent/stream-receiver/src/main/java/org/interledger/stream/receiver/StatelessStreamReceiver.java
@@ -173,6 +173,7 @@ public class StatelessStreamReceiver implements StreamReceiver {
         return InterledgerFulfillPacket.builder()
             .fulfillment(fulfillment)
             .data(encryptedReturnableStreamPacketBytes)
+            .typedData(returnableStreamPacketResponse)
             .build();
 
       } catch (IOException e) {
@@ -212,6 +213,7 @@ public class StatelessStreamReceiver implements StreamReceiver {
             .message("STREAM packet not fulfillable (prepare amount < stream packet amount)")
             .triggeredBy(receiverAddress)
             .data(encryptedReturnableStreamPacketBytes)
+            .typedData(returnableStreamPacketResponse)
             .build();
       } catch (IOException e) {
         throw new StreamException(e.getMessage(), e);


### PR DESCRIPTION
Allows any InterledgerPacket to contain a typed variant of the packet's `data` payload. This is specifically added to optimize STREAM packet handling so that different parts of the Connector or ILP node runtime do not need to re-decrypt STREAM information if a packet is operated upon at various parts of the PacketSwitch.

The field is optional so it can be added in a backwards-compatible manner (and also this contract makes the most sense because typedData may not exist in all use-cases).

Signed-off-by: David Fuelling <sappenin@gmail.com>